### PR TITLE
hadoop: add "/run" dirs with tmpfiles.d

### DIFF
--- a/roles/hadoop/defaults/main.yaml
+++ b/roles/hadoop/defaults/main.yaml
@@ -29,9 +29,9 @@ hadoop_hdfs_dir: /var/lib/hdfs
 hadoop_yarn_dir: /var/lib/yarn
 
 # Hadoop pid directories
-hadoop_pid_dir: /var/run/hadoop
-hadoop_hdfs_pid_dir: /var/run/hadoop/hdfs
-hadoop_yarn_pid_dir: /var/run/hadoop/yarn
+hadoop_pid_dir: /run/hadoop
+hadoop_hdfs_pid_dir: /run/hadoop/hdfs
+hadoop_yarn_pid_dir: /run/hadoop/yarn
 
 # Hadoop logging directory
 hadoop_log_dir: /var/log/hadoop

--- a/roles/hadoop/tasks/hadoop.yaml
+++ b/roles/hadoop/tasks/hadoop.yaml
@@ -49,6 +49,11 @@
     group: '{{ hadoop_group }}'
     owner: '{{ hdfs_user }}'
 
+- name: Template hadoop tmpfiles.d
+  template:
+    src: tmpfiles-hadoop.conf.j2
+    dest: /etc/tmpfiles.d/hadoop.conf
+
 - name: Create HDFS directory
   file:
     path: '{{ hadoop_hdfs_dir }}'

--- a/roles/hadoop/tasks/hdfs_dn.yaml
+++ b/roles/hadoop/tasks/hdfs_dn.yaml
@@ -6,6 +6,11 @@
     group: '{{ hadoop_group }}'
     owner: '{{ hdfs_user }}'
 
+- name: Template hadoop hdfs tmpfiles.d
+  template:
+    src: tmpfiles-hadoop-hdfs.conf.j2
+    dest: /etc/tmpfiles.d/hadoop-hdfs.conf
+
 - name: Create HDFS directory
   file:
     path: "{{ hdfs_site['dfs.datanode.data.dir'] }}"

--- a/roles/hadoop/tasks/hdfs_jn.yaml
+++ b/roles/hadoop/tasks/hdfs_jn.yaml
@@ -6,6 +6,11 @@
     group: '{{ hadoop_group }}'
     owner: '{{ hdfs_user }}'
 
+- name: Template hadoop hdfs tmpfiles.d
+  template:
+    src: tmpfiles-hadoop-hdfs.conf.j2
+    dest: /etc/tmpfiles.d/hadoop-hdfs.conf
+
 - name: Create HDFS Journalnode directory
   file:
     path: "{{ hdfs_site['dfs.journalnode.edits.dir'] }}"

--- a/roles/hadoop/tasks/hdfs_nn.yaml
+++ b/roles/hadoop/tasks/hdfs_nn.yaml
@@ -6,6 +6,11 @@
     group: '{{ hadoop_group }}'
     owner: '{{ hdfs_user }}'
 
+- name: Template hadoop hdfs tmpfiles.d
+  template:
+    src: tmpfiles-hadoop-hdfs.conf.j2
+    dest: /etc/tmpfiles.d/hadoop-hdfs.conf
+
 - name: Create HDFS Namenode directory
   file:
     path: "{{ hdfs_site['dfs.namenode.name.dir'] }}"

--- a/roles/hadoop/tasks/yarn_ats.yml
+++ b/roles/hadoop/tasks/yarn_ats.yml
@@ -6,6 +6,11 @@
     group: '{{ hadoop_group }}'
     owner: '{{ yarn_user }}'
 
+- name: Template hadoop yarn tmpfiles.d
+  template:
+    src: tmpfiles-hadoop-yarn.conf.j2
+    dest: /etc/tmpfiles.d/hadoop-yarn.conf
+
 - name: Create log directory
   file:
     path: '{{ hadoop_yarn_log_dir }}'

--- a/roles/hadoop/tasks/yarn_nm.yaml
+++ b/roles/hadoop/tasks/yarn_nm.yaml
@@ -6,6 +6,11 @@
     group: '{{ hadoop_group }}'
     owner: '{{ yarn_user }}'
 
+- name: Template hadoop yarn tmpfiles.d
+  template:
+    src: tmpfiles-hadoop-yarn.conf.j2
+    dest: /etc/tmpfiles.d/hadoop-yarn.conf
+
 - name: Create YARN recover directory
   file:
     path: "{{ yarn_site['yarn.nodemanager.recovery.dir'] }}"

--- a/roles/hadoop/tasks/yarn_rm.yaml
+++ b/roles/hadoop/tasks/yarn_rm.yaml
@@ -6,6 +6,11 @@
     group: '{{ hadoop_group }}'
     owner: '{{ yarn_user }}'
 
+- name: Template hadoop yarn tmpfiles.d
+  template:
+    src: tmpfiles-hadoop-yarn.conf.j2
+    dest: /etc/tmpfiles.d/hadoop-yarn.conf
+
 # - name: Create HDFS directory
 #   file:
 #     path: '{{ hadoop_hdfs_dir }}'

--- a/roles/hadoop/templates/tmpfiles-hadoop-hdfs.conf.j2
+++ b/roles/hadoop/templates/tmpfiles-hadoop-hdfs.conf.j2
@@ -1,0 +1,1 @@
+d {{ hadoop_hdfs_pid_dir }} 0755 {{ hdfs_user }} {{ hadoop_group }} -

--- a/roles/hadoop/templates/tmpfiles-hadoop-yarn.conf.j2
+++ b/roles/hadoop/templates/tmpfiles-hadoop-yarn.conf.j2
@@ -1,0 +1,1 @@
+d {{ hadoop_yarn_pid_dir }} 0755 {{ yarn_user }} {{ hadoop_group }} -

--- a/roles/hadoop/templates/tmpfiles-hadoop.conf.j2
+++ b/roles/hadoop/templates/tmpfiles-hadoop.conf.j2
@@ -1,0 +1,1 @@
+d {{ hadoop_pid_dir }} 0755 root root -


### PR DESCRIPTION
Directories inside "/run" are cleaned after a reboot. Adding conf file inside "/etc/tmpfiles.d" ensure dirs are created on boot.

See "man 5 tmpfiles.d" for the documentation.

Run dir must be "/run" and not "/var/run" which is deprecated.