### PR TITLE
Add /user/hive creation in post install

### DIFF
--- a/roles/hive/tasks/post_install.yml
+++ b/roles/hive/tasks/post_install.yml
@@ -40,6 +40,11 @@
       owner: "{{ hive_user }}"
       group: "{{ hive_user }}"
       mode: "700"
+    - path: /user/hive
+      state: directory
+      owner: "{{ hive_user }}"
+      group: "{{ hive_user }}"
+      mode: "700"
 
 - name: Put tez release to hdfs
   delegate_to: "{{ groups['hdfs_nn'][0] }}"


### PR DESCRIPTION
We need to create the folder /user/hive to allow the hive user to run Tez jobs, Tez needs to write in the "home folder" of the user running the task.

By default, we do not let hive impersonate the user, therefore any task executed by any user will be run as hive user. Therefore we need the /user/hive path to exists. (and to be writeable for the user hive)