### PR TITLE
hadoop: change hadoop pid dir owner and group

### DIFF
--- a/roles/hadoop/tasks/hadoop.yaml
+++ b/roles/hadoop/tasks/hadoop.yaml
@@ -46,8 +46,8 @@
   file:
     path: '{{ hadoop_pid_dir }}'
     state: directory
-    group: '{{ hadoop_group }}'
-    owner: '{{ hdfs_user }}'
+    group: root
+    owner: root
 
 - name: Template hadoop tmpfiles.d
   template:


### PR DESCRIPTION
hadoop pid dir is shared for HDFS, Yarn, etc. The owner should be root and not hdfs.