### PR TITLE
hbase: add hbase-rest component

### DIFF
--- a/roles/hadoop/defaults/main.yaml
+++ b/roles/hadoop/defaults/main.yaml
@@ -81,6 +81,8 @@ core_site:
     RULE:[2:$1/$2@$0](jhs/.*@{{ realm }})s/.*/mapred/
     RULE:[2:$1/$2@$0](hive/.*@{{ realm }})s/.*/hive/
     DEFAULT
+  hadoop.proxyuser.hbase.groups: "*"
+  hadoop.proxyuser.hbase.hosts: "*"
   hadoop.proxyuser.hdfs.groups: "*"
   hadoop.proxyuser.hdfs.hosts: "*"
   hadoop.proxyuser.hive.groups: "*"

--- a/roles/hbase/defaults/main.yaml
+++ b/roles/hbase/defaults/main.yaml
@@ -19,6 +19,7 @@ hadoop_conf_dir: /etc/hadoop/conf
 hbase_root_conf_dir: /etc/hbase
 hbase_master_conf_dir: "{{ hbase_root_conf_dir }}/conf.master"
 hbase_rs_conf_dir: "{{ hbase_root_conf_dir }}/conf.rs"
+hbase_rest_conf_dir: "{{ hbase_root_conf_dir }}/conf.rest"
 hbase_client_conf_dir: "{{ hbase_root_conf_dir }}/conf"
 
 # HBase pid directories
@@ -49,7 +50,7 @@ hbase_zookeeper_quorum: |
 hbase_zookeeper_client_port: "2181"
 
 # hbase_site.xml - common
-# TODO: make a hbase_site per service: master, rs, client, phoenix queryserver
+# TODO: make a hbase_site per service: master, rs, rest, client, phoenix queryserver
 hbase_site:
   hbase.rootdir: hdfs://mycluster/hbase
   hbase.cluster.distributed: "true"
@@ -66,10 +67,23 @@ hbase_site:
   hbase.master.kerberos.principal: "hbase/_HOST@{{ realm }}"
   hbase.regionserver.keytab.file: /etc/security/keytabs/hbase.service.keytab
   hbase.regionserver.kerberos.principal: "hbase/_HOST@{{ realm }}"
+  hbase.rest.keytab.file: /etc/security/keytabs/hbase.service.keytab
+  hbase.rest.kerberos.principal: "hbase/_HOST@{{ realm }}"
+  hbase.rest.authentication.type: kerberos
+  hbase.rest.authentication.kerberos.keytab: /etc/security/keytabs/spnego.service.keytab
+  hbase.rest.authentication.kerberos.principal: "HTTP/_HOST@{{ realm }}"
+  hbase.rest.support.proxyuser: "true"
+  hbase.rest.ssl.enabled: "true"
+  hbase.rest.ssl.keystore.store: "{{ hbase_keystore_location }}"
+  hbase.rest.ssl.keystore.password: "{{ hbase_keystore_password }}"
+  hbase.rest.port: 8080
+  hbase.rest.info.port: 8085
+  hbase.coprocessor.region.classes: org.apache.hadoop.hbase.security.token.TokenProvider
 
 # JAAS principals need the FQDN
 hbase_master_kerberos_principal: "hbase/{{ ansible_fqdn }}@{{ realm }}"
 hbase_regionserver_kerberos_principal: "hbase/{{ ansible_fqdn }}@{{ realm }}"
+hbase_rest_kerberos_principal: "hbase/{{ ansible_fqdn }}@{{ realm }}"
 
 # HBase Ranger Plugin
 ranger_hbase_release: ranger-2.0.1-TDP-0.1.0-SNAPSHOT-hbase-plugin
@@ -85,6 +99,7 @@ ranger_hbase_install_properties:
 # Service restart policies
 hbase_master_restart: "no"
 hbase_rs_restart: "no"
+hbase_rest_restart: "no"
 phoenix_queryserver_restart: "no"
 
 # Phoenix version

--- a/roles/hbase/tasks/hbase_rest.yaml
+++ b/roles/hbase/tasks/hbase_rest.yaml
@@ -1,0 +1,133 @@
+---
+- name: Create configuration directory
+  file:
+    path: '{{ hbase_rest_conf_dir }}'
+    state: directory
+    group: '{{ hadoop_group }}'
+    owner: '{{ hbase_user }}'
+
+- name: Backup configuration
+  copy:
+    src: '{{ hbase_rest_conf_dir }}/'
+    dest: '{{ hbase_rest_conf_dir }}.{{ ansible_date_time.epoch }}'
+    group: '{{ hadoop_group }}'
+    owner: '{{ hbase_user }}'
+    remote_src: yes
+  tags:
+    - backup
+
+- name: Template hbase-env.sh
+  template:
+    src: hbase/hbase-env.sh.j2
+    dest: '{{ hbase_rest_conf_dir }}/hbase-env.sh'
+
+- name: Template log4j.properties
+  template:
+    src: hbase/log4j.properties.j2
+    dest: '{{ hbase_rest_conf_dir }}/log4j.properties'
+
+- name: Template HBase REST service file
+  template:
+    src: hbase/hbase-rest.service.j2
+    dest: /usr/lib/systemd/system/hbase-rest.service
+
+- name: Template krb5 JAAS
+  template:
+    src: hbase/krb5JAASServer.conf.j2
+    dest: '{{ hbase_rest_conf_dir }}/krb5JAASServer.conf'
+  vars:
+    hbase_keytab_file: "{{ hbase_site['hbase.rest.keytab.file'] }}"
+    hbase_principal: "{{ hbase_rest_kerberos_principal }}"
+
+- name: Render hbase-site.xml
+  template:
+    src: hbase/hbase-site.xml.j2
+    dest: '{{ hbase_rest_conf_dir }}/hbase-site.xml'
+
+- name: Render ssl-server.xml
+  template:
+    src: hbase/ssl-server.xml.j2
+    dest: '{{ hbase_rest_conf_dir }}/ssl-server.xml'
+
+- name: Copy core-site.xml
+  copy:
+    src: /etc/hadoop/conf/core-site.xml
+    dest: '{{ hbase_rest_conf_dir }}/core-site.xml'
+    remote_src: yes
+
+- name: Copy hdfs-site.xml
+  copy:
+    src: /etc/hadoop/conf/hdfs-site.xml
+    dest: '{{ hbase_rest_conf_dir }}/hdfs-site.xml'
+    remote_src: yes
+
+- name: Generate principals and keytabs
+  shell: |
+    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "addprinc -randkey hbase/{{ ansible_fqdn }}"
+    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "xst -k hbase.service.keytab hbase/{{ ansible_fqdn }}@{{ realm }}"
+    chown {{ hbase_user }}:{{ hadoop_group }} hbase.service.keytab
+  args:
+    chdir: /etc/security/keytabs
+    creates: /etc/security/keytabs/hbase.service.keytab
+
+- name: Generate principals and keytabs for spnego
+  shell: |
+    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "addprinc -randkey HTTP/{{ ansible_fqdn }}"
+    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "xst -k spnego.service.keytab HTTP/{{ ansible_fqdn }}@{{ realm }}"
+    chown {{ hbase_user }}:{{ hadoop_group }} spnego.service.keytab
+  args:
+    chdir: /etc/security/keytabs
+    creates: /etc/security/keytabs/spnego.service.keytab
+
+- name: Ensure spnego keytab mode is 640
+  file:
+    path: /etc/security/keytabs/spnego.service.keytab
+    mode: '640'
+
+- name: Convert cert and key to pk12
+  shell: |
+    openssl pkcs12 \
+      -export \
+      -in /etc/ssl/certs/{{ ansible_fqdn }}.pem \
+      -inkey /etc/ssl/certs/{{ ansible_fqdn }}.key \
+      -out /etc/ssl/certs/{{ ansible_fqdn }}.p12 \
+      -name {{ ansible_fqdn }} \
+      -CAfile /etc/ssl/certs/root.pem \
+      -caname root_ca \
+      -password pass:{{ hbase_keystore_password }}
+  args:
+    creates: '/etc/ssl/certs/{{ ansible_fqdn }}.p12'
+
+- name: Create keystore and add Certificate Authority into it
+  shell: |
+    keytool \
+      -importkeystore \
+      -deststorepass {{ hbase_keystore_password }} \
+      -destkeypass {{ hbase_keystore_password }} \
+      -destkeystore {{ hbase_keystore_location }} \
+      -srckeystore /etc/ssl/certs/{{ ansible_fqdn }}.p12 \
+      -srcstoretype PKCS12 \
+      -srcstorepass {{ hbase_keystore_password }} \
+      -alias {{ ansible_fqdn }}
+
+    keytool \
+      -keystore {{ hbase_keystore_location }} \
+      -alias root_ca \
+      -import \
+      -file /etc/ssl/certs/root.pem \
+      -storepass {{ hbase_keystore_password }} \
+      -noprompt
+  args:
+    creates: '{{ hbase_keystore_location }}'
+
+- name: Create truststore
+  shell: |
+    keytool \
+    -keystore {{ hbase_truststore_location }} \
+    -deststorepass {{ hbase_truststore_password }} \
+    -alias root_ca \
+    -import \
+    -file /etc/ssl/certs/root.pem \
+    -noprompt
+  args:
+    creates: '{{ hbase_truststore_location }}'

--- a/roles/hbase/tasks/main.yaml
+++ b/roles/hbase/tasks/main.yaml
@@ -7,6 +7,9 @@
 - include_tasks: hbase_rs.yaml
   when: "'hbase_rs' in group_names"
 
+- include_tasks: hbase_rest.yaml
+  when: "'hbase_rest' in group_names"
+
 - include_tasks: ranger_hbase_plugin.yaml
   when: "['hbase_master', 'hbase_rs'] | intersect(group_names) | count > 0"
 

--- a/roles/hbase/tasks/post_install.yml
+++ b/roles/hbase/tasks/post_install.yml
@@ -49,6 +49,13 @@
     state: started
   loop: "{{ groups['hbase_rs'] }}"
 
+- name: Start HBase REST
+  delegate_to: "{{ item }}"
+  service:
+    name: hbase-rest
+    state: started
+  loop: "{{ groups['hbase_rest'] }}"
+
 - name: Start Phoenix QueryServer
   delegate_to: "{{ item }}"
   service:

--- a/roles/hbase/templates/hbase/hbase-env.sh.j2
+++ b/roles/hbase/templates/hbase/hbase-env.sh.j2
@@ -138,3 +138,4 @@ export HBASE_MANAGES_ZK=false
 export HBASE_OPTS="$HBASE_OPTS -Djava.security.auth.login.config={{ hbase_client_conf_dir }}/krb5JAASClient.conf"
 export HBASE_MASTER_OPTS="-Djava.security.auth.login.config={{ hbase_master_conf_dir }}/krb5JAASServer.conf"
 export HBASE_REGIONSERVER_OPTS="-Djava.security.auth.login.config={{ hbase_rs_conf_dir }}/krb5JAASServer.conf"
+export HBASE_REST_OPTS="-Djava.security.auth.login.config={{ hbase_rest_conf_dir }}/krb5JAASServer.conf"

--- a/roles/hbase/templates/hbase/hbase-rest.service.j2
+++ b/roles/hbase/templates/hbase/hbase-rest.service.j2
@@ -1,0 +1,15 @@
+[Unit]
+Description=HBase REST
+
+[Service]
+User={{ hbase_user }}
+Group={{ hadoop_group }}
+PIDFile={{ hbase_pid_dir }}/hbase-hbase-rest.pid
+ExecStart={{ hbase_install_dir }}/bin/hbase-daemon.sh --config {{ hbase_rest_conf_dir }} foreground_start rest
+ExecReload={{ hbase_install_dir }}/bin/hbase-daemon.sh --config {{ hbase_rest_conf_dir }} restart rest
+ExecStop={{ hbase_install_dir }}/bin/hbase-daemon.sh --config {{ hbase_rest_conf_dir }} stop rest
+LimitNOFILE=64000
+Restart={{ hbase_rest_restart}}
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/hbase/templates/hbase/hbase-site.xml.j2
+++ b/roles/hbase/templates/hbase/hbase-site.xml.j2
@@ -1,8 +1,8 @@
 <configuration>
-  {% for name, value in hbase_site.items() %}
+{% for name, value in hbase_site.items() %}
   <property>
     <name>{{ name }}</name>
     <value>{{ value }}</value>
   </property>
-  {% endfor %}
+{% endfor %}
 </configuration>

--- a/roles/hbase/templates/hbase/ssl-server.xml.j2
+++ b/roles/hbase/templates/hbase/ssl-server.xml.j2
@@ -1,8 +1,8 @@
 <configuration>
-  {% for name, value in ssl_server.items() %}
+{% for name, value in ssl_server.items() %}
   <property>
     <name>{{ name }}</name>
     <value>{{ value }}</value>
   </property>
-  {% endfor %}
+{% endfor %}
 </configuration>

--- a/roles/hbase/templates/phoenix_queryserver/hbase-site.xml.j2
+++ b/roles/hbase/templates/phoenix_queryserver/hbase-site.xml.j2
@@ -1,8 +1,8 @@
 <configuration>
-  {% for name, value in phoenix_queryserver_properties.items() %}
+{% for name, value in phoenix_queryserver_properties.items() %}
   <property>
     <name>{{ name }}</name>
     <value>{{ value }}</value>
   </property>
-  {% endfor %}
+{% endfor %}
 </configuration>


### PR DESCRIPTION
These tasks add the deployment of the HBase REST component
Issue link: #39 

# Examples

## Get cluster version
```shell
$ curl -k --negotiate -u ":" -H 'Accept: application/json' https://host-1.lan:8080/version/cluster
```

```json
{"Version":"2.1.10-TDP-0.1.0-SNAPSHOT"}
```

## Get table list
```shell
curl -k --negotiate -u ":"  -H 'Accept: application/json' https://host-1.lan:8080/
```

```json
{"table":[{"name":"SYSTEM.CATALOG"},{"name":"SYSTEM.CHILD_LINK"},{"name":"SYSTEM.FUNCTION"},{"name":"SYSTEM.LOG"},{"name":"SYSTEM.MUTEX"},{"name":"SYSTEM.SEQUENCE"},{"name":"SYSTEM.STATS"},{"name":"SYSTEM.TASK"}]}
```

