### PR TITLE
hadoop: secure zookeeper ha node

### DIFF
--- a/roles/hadoop/defaults/main.yaml
+++ b/roles/hadoop/defaults/main.yaml
@@ -33,6 +33,10 @@ hadoop_pid_dir: /run/hadoop
 hadoop_hdfs_pid_dir: /run/hadoop/hdfs
 hadoop_yarn_pid_dir: /run/hadoop/yarn
 
+# ZKFC options
+hdfs_zkfc_opts: ""
+hdfs_zkfc_nn_opts: "-Djava.security.auth.login.config={{ hadoop_nn_conf_dir }}/krb5JAASnn.conf"
+
 # Hadoop logging directory
 hadoop_log_dir: /var/log/hadoop
 hadoop_hdfs_log_dir: /var/log/hadoop/hdfs
@@ -72,6 +76,7 @@ hadoop_ha_zookeeper_quorum: |
 core_site:
   fs.defaultFS: "hdfs://mycluster"
   ha.zookeeper.quorum: "{{ hadoop_ha_zookeeper_quorum | trim }}"
+  ha.zookeeper.acl: sasl:nn:rwcda
   hadoop.rpc.protection: authentication
   hadoop.security.authentication: kerberos
   hadoop.security.authorization: "true"
@@ -144,6 +149,8 @@ hdfs_site:
   dfs.datanode.data.dir: "{{ hadoop_hdfs_dir }}/dn"
   dfs.datanode.kerberos.principal: dn/_HOST@{{ realm }}
   dfs.datanode.keytab.file: /etc/security/keytabs/dn.service.keytab
+
+namenode_kerberos_principal: "nn/{{ ansible_fqdn }}@{{ realm }}"
 
 # TODO: make a yarn_site per service: rm, nm, ts
 yarn_site:

--- a/roles/hadoop/tasks/hdfs_nn.yaml
+++ b/roles/hadoop/tasks/hdfs_nn.yaml
@@ -49,6 +49,12 @@
   vars:
     hadoop_log_dir: "{{ hadoop_hdfs_log_dir }}"
     hadoop_pid_dir: "{{ hadoop_hdfs_pid_dir }}"
+    hdfs_zkfc_opts: "{{ hdfs_zkfc_nn_opts }}"
+
+- name: Template krb5 jaas
+  template:
+    src: krb5JAASnn.conf.j2
+    dest: '{{ hadoop_nn_conf_dir }}/krb5JAASnn.conf'
 
 - name: Template log4j.properties
   template:

--- a/roles/hadoop/templates/hadoop-env.sh.j2
+++ b/roles/hadoop/templates/hadoop-env.sh.j2
@@ -420,3 +420,5 @@ export HADOOP_PID_DIR={{ hadoop_pid_dir }}
 #
 # For example, to limit who can execute the namenode command,
 # export HDFS_NAMENODE_USER=hdfs
+
+export HDFS_ZKFC_OPTS="{{ hdfs_zkfc_opts }} ${HDFS_ZKFC_OPTS}"

--- a/roles/hadoop/templates/krb5JAASnn.conf.j2
+++ b/roles/hadoop/templates/krb5JAASnn.conf.j2
@@ -1,0 +1,8 @@
+Client {
+    com.sun.security.auth.module.Krb5LoginModule required
+    useKeyTab=true
+    storeKey=true
+    useTicketCache=false
+    keyTab="{{ hdfs_site['dfs.namenode.keytab.file'] }}"
+    principal="{{ namenode_kerberos_principal }}";
+};


### PR DESCRIPTION
Fix #28 

To check ACLs:
```bash
export CLIENT_JVMFLAGS="-Djava.security.auth.login.config=/etc/hadoop/conf.nn/krb5JAASnn.conf"
$ zkCli.sh
[zk: localhost:2181(CONNECTED) 0] getAcl /hadoop-ha
'sasl,'nn
: cdrwa

```

Tests performs: 
Shutdown namenodes in turn, and check the failover worked