### PR TITLE
hive: get password from credentials provider

### DIFF
--- a/roles/hive/defaults/main.yaml
+++ b/roles/hive/defaults/main.yaml
@@ -34,7 +34,9 @@ hive_jdbc_connector_package: mysql-connector-java
 hive_ms_db_url: jdbc:mysql://tdp-db-1.lxd:3306
 hive_ms_db_name: hive
 hive_ms_db_user: hive
-hive_ms_db_password: hive122
+hive_ms_db_password: hive123
+hive_ms_credentials_store_path: "{{ hive_s2_conf_dir }}/hive.jceks"
+hive_ms_credentials_store_uri: localjceks://file{{ hive_ms_credentials_store_path }}
 db_type: mysql
 
 # SSL Keystore and Truststore
@@ -47,8 +49,8 @@ hive_truststore_password: Truststore123!
 hive_site:
 # javax.jdo.option.ConnectionURL: "{{ hive_ms_db_url }}/{{ hive_ms_db_name }}"
   javax.jdo.option.ConnectionDriverName: com.mysql.jdbc.Driver
-  javax.jdo.option.ConnectionUserName: hive
-  javax.jdo.option.ConnectionPassword: hive123
+  javax.jdo.option.ConnectionUserName: "{{ hive_ms_db_user }}"
+  hadoop.security.credential.provider.path: "{{ hive_ms_credentials_store_uri }}"
   hive.exec.scratchdir: /tmp/hive
   hive.metastore.warehouse.dir: /warehouse/tablespace/managed/hive
   hive.metastore.warehouse.external.dir: /warehouse/tablespace/external/hive

--- a/roles/hive/tasks/hive_s2.yaml
+++ b/roles/hive/tasks/hive_s2.yaml
@@ -90,6 +90,18 @@
   args:
     creates: '{{ hive_truststore_location }}'
 
+- name: Create hive credentials store
+  shell: |
+    {{ hadoop_home }}/bin/hadoop credential create javax.jdo.option.ConnectionPassword -value {{ hive_ms_db_password }} -provider {{ hive_ms_credentials_store_uri }}
+  args:
+    creates: '{{ hive_ms_credentials_store_path }}'
+
+- name: Ensure hive credentials store is 600 and owned by hive
+  file:
+    path: '{{ hive_ms_credentials_store_path }}'
+    mode: '600'
+    owner: '{{ hive_user }}'
+
 - name: Generate principals and keytabs
   shell: |
     kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "addprinc -randkey hive/{{ ansible_fqdn }}"


### PR DESCRIPTION
Fix #31 

From what I gather, it's not possible to put `javax.jdo.option.ConnectionUserName` inside a credentials store.

From an existing cluster, you need to restart Hive Metastore Server and HiveServer2.