### PR TITLE
all: roles refactoring for kerberos integration with hdfs_file plugin

### DIFF
--- a/roles/hadoop/hdfs/namenode/tasks/init.yml
+++ b/roles/hadoop/hdfs/namenode/tasks/init.yml
@@ -2,14 +2,6 @@
 - import_role:
     name: tosit.tdp.hadoop.common
 
-- name: Kinit for hdfs
-  delegate_to: "{{ groups['hdfs_nn'][0] }}"
-  run_once: yes
-  command: "kinit -kt /etc/security/keytabs/nn.service.keytab nn/{{ groups['hdfs_nn'][0] | tosit.tdp.access_fqdn(hostvars) }}@{{ realm }}"
-  become: yes
-  become_user: "{{ hdfs_user }}"
-  changed_when: no
-
 - name: Add directory for hdfs, yarn and ranger
   delegate_to: "{{ groups['hdfs_nn'][0] }}"
   run_once: yes
@@ -20,6 +12,9 @@
     owner: "{{ item.owner | default(omit) }}"
     group: "{{ item.group | default(omit) }}"
     mode: "{{ item.mode | default(omit) }}"
+    kerberos: yes
+    krb_principal: "nn/{{ groups['hdfs_nn'][0] | tosit.tdp.access_fqdn(hostvars) }}@{{ realm }}"
+    krb_keytab: /etc/security/keytabs/nn.service.keytab
   become: yes
   become_user: "{{ hdfs_user }}"
   loop:

--- a/roles/hbase/master/tasks/hdfs_init.yml
+++ b/roles/hbase/master/tasks/hdfs_init.yml
@@ -2,14 +2,6 @@
 - import_role:
     name: tosit.tdp.hbase.common
 
-- name: Kinit for hdfs
-  delegate_to: "{{ groups['hdfs_nn'][0] }}"
-  run_once: yes
-  command: "kinit -kt /etc/security/keytabs/nn.service.keytab nn/{{ groups['hdfs_nn'][0] | tosit.tdp.access_fqdn(hostvars) }}@{{ realm }}"
-  become: yes
-  become_user: "{{ hdfs_user }}"
-  changed_when: no
-
 - name: Add directories for hbase
   delegate_to: "{{ groups['hdfs_nn'][0] }}"
   run_once: yes
@@ -20,6 +12,9 @@
     owner: "{{ item.owner | default(omit) }}"
     group: "{{ item.group | default(omit) }}"
     mode: "{{ item.mode | default(omit) }}"
+    kerberos: yes
+    krb_principal: "nn/{{ groups['hdfs_nn'][0] | tosit.tdp.access_fqdn(hostvars) }}@{{ realm }}"
+    krb_keytab: /etc/security/keytabs/nn.service.keytab
   become: yes
   become_user: "{{ hdfs_user }}"
   loop:

--- a/roles/hive/common/tasks/hdfs_init.yml
+++ b/roles/hive/common/tasks/hdfs_init.yml
@@ -1,12 +1,4 @@
 ---
-- name: Kinit for hdfs
-  delegate_to: "{{ groups['hdfs_nn'][0] }}"
-  run_once: yes
-  command: "kinit -kt /etc/security/keytabs/nn.service.keytab nn/{{ groups['hdfs_nn'][0] | tosit.tdp.access_fqdn(hostvars) }}@{{ realm }}"
-  become: yes
-  become_user: "{{ hdfs_user }}"
-  changed_when: no
-
 - name: Add directory for hive
   delegate_to: "{{ groups['hdfs_nn'][0] }}"
   run_once: yes
@@ -17,6 +9,9 @@
     owner: "{{ item.owner | default(omit) }}"
     group: "{{ item.group | default(omit) }}"
     mode: "{{ item.mode | default(omit) }}"
+    kerberos: yes
+    krb_principal: "nn/{{ groups['hdfs_nn'][0] | tosit.tdp.access_fqdn(hostvars) }}@{{ realm }}"
+    krb_keytab: /etc/security/keytabs/nn.service.keytab
   become: yes
   become_user: "{{ hdfs_user }}"
   loop:
@@ -47,6 +42,14 @@
       owner: "{{ hive_user }}"
       group: "{{ hive_user }}"
       mode: "700"
+
+- name: Kinit for hdfs
+  delegate_to: "{{ groups['hdfs_nn'][0] }}"
+  run_once: yes
+  command: "kinit -kt /etc/security/keytabs/nn.service.keytab nn/{{ groups['hdfs_nn'][0] | tosit.tdp.access_fqdn(hostvars) }}@{{ realm }}"
+  become: yes
+  become_user: "{{ hdfs_user }}"
+  changed_when: no
 
 - name: Put tez release to hdfs
   delegate_to: "{{ groups['hdfs_nn'][0] }}"

--- a/roles/spark/common/tasks/hdfs_init.yml
+++ b/roles/spark/common/tasks/hdfs_init.yml
@@ -1,12 +1,4 @@
 ---
-- name: Kinit for hdfs
-  delegate_to: "{{ groups['hdfs_nn'][0] }}"
-  run_once: yes
-  command: "kinit -kt /etc/security/keytabs/nn.service.keytab nn/{{ groups['hdfs_nn'][0] | tosit.tdp.access_fqdn(hostvars) }}@{{ realm }}"
-  become: yes
-  become_user: "{{ hdfs_user }}"
-  changed_when: no
-
 - name: Add directory for spark logs
   delegate_to: "{{ groups['hdfs_nn'][0] }}"
   run_once: yes
@@ -17,6 +9,9 @@
     owner: "{{ item.owner | default(omit) }}"
     group: "{{ item.group | default(omit) }}"
     mode: "{{ item.mode | default(omit) }}"
+    kerberos: yes
+    krb_principal: "nn/{{ groups['hdfs_nn'][0] | tosit.tdp.access_fqdn(hostvars) }}@{{ realm }}"
+    krb_keytab: /etc/security/keytabs/nn.service.keytab
   become: yes
   become_user: "{{ hdfs_user }}"
   loop:


### PR DESCRIPTION
Fix #78 description: 

Direct kerberos integration with `hdfs_file` plugin instead of doing `kinit` before `hdfs_file`