### PR TITLE
hadoop: split variables into multiple defaults

### DIFF
--- a/roles/hadoop/client/defaults/main.yml
+++ b/roles/hadoop/client/defaults/main.yml
@@ -1,0 +1,12 @@
+# Hadoop configuration directories
+hadoop_client_conf_dir: "{{ hadoop_root_conf_dir }}/conf"
+
+# mapred-site.xml
+mapred_site:
+  mapreduce.framework.name: yarn
+  mapreduce.map.memory.mb: 1024
+  mapreduce.reduce.memory.mb: 2048
+  mapreduce.map.java.opts: -Xmx768m
+  mapreduce.reduce.java.opts: -Xmx1536m
+  mapreduce.application.classpath: /opt/tdp/hadoop/share/hadoop/mapreduce/*,/opt/tdp/hadoop/share/hadoop/mapreduce/lib/*,/etc/hadoop/conf/
+  mapreduce.jobhistory.address: "{{ groups['yarn_ats'][0] | tosit.tdp.access_fqdn(hostvars) }}:10200"

--- a/roles/hadoop/common/defaults/main.yml
+++ b/roles/hadoop/common/defaults/main.yml
@@ -15,14 +15,6 @@ hadoop_install_dir: "{{ hadoop_root_dir }}/hadoop"
 
 # Hadoop configuration directories
 hadoop_root_conf_dir: /etc/hadoop
-hadoop_nn_conf_dir: "{{ hadoop_root_conf_dir }}/conf.nn"
-hadoop_dn_conf_dir: "{{ hadoop_root_conf_dir }}/conf.dn"
-hadoop_jn_conf_dir: "{{ hadoop_root_conf_dir }}/conf.jn"
-hadoop_zkfc_conf_dir: "{{ hadoop_root_conf_dir }}/conf.zkfc"
-hadoop_client_conf_dir: "{{ hadoop_root_conf_dir }}/conf"
-hadoop_rm_conf_dir: "{{ hadoop_root_conf_dir }}/conf.rm"
-hadoop_nm_conf_dir: "{{ hadoop_root_conf_dir }}/conf.nm"
-hadoop_ats_conf_dir: "{{ hadoop_root_conf_dir }}/conf.ats"
 
 # Hadoop HDFS/YARN directories
 hadoop_hdfs_dir: /var/lib/hdfs
@@ -35,7 +27,6 @@ hadoop_yarn_pid_dir: /run/hadoop/yarn
 
 # ZKFC options
 hdfs_zkfc_opts: ""
-hdfs_zkfc_nn_opts: "-Djava.security.auth.login.config={{ hadoop_nn_conf_dir }}/krb5JAASnn.conf"
 
 # Hadoop logging directory
 hadoop_log_dir: /var/log/hadoop
@@ -119,40 +110,12 @@ hdfs_site:
   dfs.data.transfer.protection: authentication
   dfs.web.authentication.kerberos.keytab: /etc/security/keytabs/spnego.service.keytab
   dfs.web.authentication.kerberos.principal: "HTTP/_HOST@{{ realm }}"
-  # dfs.namenode.https-address: 0.0.0.0:9871
   dfs.namenode.rpc-address.mycluster.nn1: "{{ groups['hdfs_nn'][0] | tosit.tdp.access_fqdn(hostvars) }}:8020"
   dfs.namenode.rpc-address.mycluster.nn2: "{{ groups['hdfs_nn'][1] | tosit.tdp.access_fqdn(hostvars) }}:8020"
-  dfs.namenode.http-address.mycluster.nn1: "{{ groups['hdfs_nn'][0] | tosit.tdp.access_fqdn(hostvars) }}:9870"
-  dfs.namenode.http-address.mycluster.nn2: "{{ groups['hdfs_nn'][1] | tosit.tdp.access_fqdn(hostvars) }}:9870"
-  dfs.namenode.https-address.mycluster.nn1: "{{ groups['hdfs_nn'][0] | tosit.tdp.access_fqdn(hostvars) }}:9871"
-  dfs.namenode.https-address.mycluster.nn2: "{{ groups['hdfs_nn'][1] | tosit.tdp.access_fqdn(hostvars) }}:9871"
-  dfs.namenode.name.dir: "{{ hadoop_hdfs_dir }}/nn"
-  dfs.namenode.shared.edits.dir: |
-    qjournal://{{ groups['hdfs_jn'] | 
-       map('tosit.tdp.access_fqdn', hostvars) |
-       map('regex_replace', '^(.*)$', '\1:8485') |
-       list |
-       join(';')
-    }}/mycluster
-
-  dfs.namenode.kerberos.principal: "nn/_HOST@{{ realm }}"
-  dfs.namenode.keytab.file: /etc/security/keytabs/nn.service.keytab
-  dfs.namenode.kerberos.internal.spnego.principal: "HTTP/_HOST@{{ realm }}"
   dfs.client.failover.proxy.provider.mycluster: org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider
-  dfs.journalnode.edits.dir: "{{ hadoop_hdfs_dir }}/jn"
-  dfs.journalnode.rpc-address: 0.0.0.0:8485
-  dfs.journalnode.https-address: 0.0.0.0:8481
   dfs.journalnode.kerberos.principal: jn/_HOST@{{ realm }}
   dfs.journalnode.keytab.file: /etc/security/keytabs/jn.service.keytab
-  dfs.journalnode.kerberos.internal.spnego.principal: "HTTP/_HOST@{{ realm }}"
   dfs.block.access.token.enable: "true"
-  dfs.datanode.address: 0.0.0.0:9866
-  dfs.datanode.https.address: 0.0.0.0:9865
-  dfs.datanode.data.dir: "{{ hadoop_hdfs_dir }}/dn"
-  dfs.datanode.kerberos.principal: dn/_HOST@{{ realm }}
-  dfs.datanode.keytab.file: /etc/security/keytabs/dn.service.keytab
-
-namenode_kerberos_principal: "nn/{{ ansible_fqdn }}@{{ realm }}"
 
 # TODO: make a yarn_site per service: rm, nm, ts
 yarn_site:
@@ -160,122 +123,11 @@ yarn_site:
   yarn.application.classpath: "$HADOOP_CONF_DIR, {{ hadoop_install_dir }}/share/hadoop/common/*, {{ hadoop_install_dir }}/share/hadoop/common/lib/*, {{ hadoop_install_dir }}/share/hadoop/hdfs/*, {{ hadoop_install_dir }}/share/hadoop/hdfs/lib/*, {{ hadoop_install_dir }}/share/hadoop/yarn/*, {{ hadoop_install_dir }}/share/hadoop/yarn/lib/*"
   yarn.http.policy: HTTPS_ONLY
   yarn.log-aggregation-enable: "true"
-  yarn.nodemanager.remote-app-log-dir: "/app-logs"
-  yarn.nodemanager.remote-app-log-dir-suffix : "logs"
   yarn.resourcemanager.ha.enabled: "true"
   yarn.resourcemanager.ha.rm-ids: "rm1,rm2"
   yarn.resourcemanager.cluster-id: "mycluster"
   yarn.resourcemanager.hostname.rm1: "{{ groups['yarn_rm'][0] | tosit.tdp.access_fqdn(hostvars) }}"
   yarn.resourcemanager.hostname.rm2: "{{ groups['yarn_rm'][1] | tosit.tdp.access_fqdn(hostvars) }}"
-  yarn.resourcemanager.webapp.address.rm1: "{{ groups['yarn_rm'][0] | tosit.tdp.access_fqdn(hostvars) }}:8088"
-  yarn.resourcemanager.webapp.address.rm2: "{{ groups['yarn_rm'][1] | tosit.tdp.access_fqdn(hostvars) }}:8088"
-  yarn.resourcemanager.webapp.https.address.rm1: "{{ groups['yarn_rm'][0] | tosit.tdp.access_fqdn(hostvars) }}:8090"
-  yarn.resourcemanager.webapp.https.address.rm2: "{{ groups['yarn_rm'][1] | tosit.tdp.access_fqdn(hostvars) }}:8090"
-  yarn.resourcemanager.webapp.spnego-keytab-file: /etc/security/keytabs/spnego.service.keytab
-  yarn.resourcemanager.webapp.spnego-principal: "HTTP/_HOST@{{ realm }}"
   yarn.resourcemanager.keytab: /etc/security/keytabs/rm.service.keytab
   yarn.resourcemanager.principal: "rm/_HOST@{{ realm }}"
-  yarn.resourcemanager.system-metrics-publisher.enabled: "true"
-  yarn.resourcemanager.recovery.enabled: "true"
-  yarn.resourcemanager.store.class: "org.apache.hadoop.yarn.server.resourcemanager.recovery.ZKRMStateStore"
-  yarn.nodemanager.local-dirs: /data/yarn/local
-  yarn.nodemanager.log-dirs: /data/yarn/logs
-  yarn.nodemanager.container-executor.class: org.apache.hadoop.yarn.server.nodemanager.LinuxContainerExecutor
-  yarn.nodemanager.linux-container-executor.group: hadoop
-  yarn.nodemanager.aux-services: mapreduce_shuffle
-  yarn.nodemanager.aux-services.mapreduce_shuffle.class: org.apache.hadoop.mapred.ShuffleHandler
-  yarn.nodemanager.address: 0.0.0.0:45454
-  yarn.nodemanager.bind-host: 0.0.0.0
-  yarn.nodemanager.webapp.address: 0.0.0.0:8042
-  yarn.nodemanager.webapp.https.address: 0.0.0.0:8044
-  yarn.nodemanager.recovery.enabled: true
-  yarn.nodemanager.recovery.dir: "{{ hadoop_yarn_dir }}"
-  yarn.nodemanager.resource.cpu-vcores: 8
-  yarn.nodemanager.resource.memory-mb: 8192
-  yarn.scheduler.minimum-allocation-mb: 1024
-  yarn.scheduler.maximum-allocation-mb: 8192
-  yarn.nodemanager.principal: "nm/_HOST@{{ realm }}"
-  yarn.nodemanager.keytab: /etc/security/keytabs/nm.service.keytab
-  yarn.nodemanager.webapp.spnego-keytab-file: /etc/security/keytabs/spnego.service.keytab
-  yarn.nodemanager.webapp.spnego-principal: "HTTP/_HOST@{{ realm }}"
-  #yarn.nodemanager.vmem-check-enabled: "false"
-  yarn.nodemanager.vmem-pmem-ratio: 4
-  yarn.timeline-service.enabled: "true"
-  yarn.timeline-service.generic-application-history.enabled: "true"
-  yarn.timeline-service.hostname: "{{ groups['yarn_ats'][0] | tosit.tdp.access_fqdn(hostvars) }}"
-  yarn.timeline-service.address: 0.0.0.0:10200
-  yarn.timeline-service.webapp.https.address: "{{ groups['yarn_ats'][0] | tosit.tdp.access_fqdn(hostvars) }}:8190"
-  yarn.timeline-service.principal: ats/_HOST@{{ realm }}
-  yarn.timeline-service.keytab: /etc/security/keytabs/ats.service.keytab
-  # To enable Kerberos on the ATS UI
-  # yarn.timeline-service.http-authentication.type: kerberos
-  # yarn.timeline-service.http-authentication.kerberos.principal: HTTP/_HOST@{{ realm }}
-  # yarn.timeline-service.http-authentication.kerberos.keytab: /etc/security/keytabs/spnego.service.keytab
-  yarn.acl.enable: "true"
-  yarn.admin.acl: yarn
 
-
-# mapred-site.xml
-mapred_site:
-  mapreduce.framework.name: yarn
-  mapreduce.map.memory.mb: 1024
-  mapreduce.reduce.memory.mb: 2048
-  mapreduce.map.java.opts: -Xmx768m
-  mapreduce.reduce.java.opts: -Xmx1536m
-  mapreduce.application.classpath: /opt/tdp/hadoop/share/hadoop/mapreduce/*,/opt/tdp/hadoop/share/hadoop/mapreduce/lib/*,/etc/hadoop/conf/
-  mapreduce.jobhistory.address: "{{ groups['yarn_ats'][0] | tosit.tdp.access_fqdn(hostvars) }}:10200"
-  
-
-# container-executor.cfg
-container_executor:
-  yarn.nodemanager.local-dirs: "{{ yarn_site['yarn.nodemanager.local-dirs'] }}"
-  yarn.nodemanager.log-dirs: "{{ yarn_site['yarn.nodemanager.log-dirs'] }}"
-  yarn.nodemanager.linux-container-executor.group: "{{ hadoop_group }}"
-  banned.users: hdfs,yarn,mapred,bin
-  min.user.id: 1000
-
-# Ranger HDFS properties
-ranger_hdfs_release: ranger-2.0.1-TDP-0.1.0-SNAPSHOT-hdfs-plugin
-ranger_hdfs_dist_file: "{{ ranger_hdfs_release }}.tar.gz"
-ranger_hdfs_install_dir: "{{ hadoop_root_dir }}/ranger-hdfs-plugin"
-ranger_hdfs_install_properties:
-  POLICY_MGR_URL: "https://{{ groups['ranger_admin'][0] | tosit.tdp.access_fqdn(hostvars) }}:6182"
-  REPOSITORY_NAME: hdfs-tdp
-
-# Ranger YARN properties
-ranger_yarn_release: ranger-2.0.1-TDP-0.1.0-SNAPSHOT-yarn-plugin
-ranger_yarn_dist_file: "{{ ranger_yarn_release }}.tar.gz"
-ranger_yarn_install_dir: "{{ hadoop_root_dir }}/ranger-yarn-plugin"
-ranger_yarn_install_properties:
-  POLICY_MGR_URL: "https://{{ groups['ranger_admin'][0] | tosit.tdp.access_fqdn(hostvars) }}:6182"
-  REPOSITORY_NAME: yarn-tdp
-
-capacity_scheduler:
-  yarn.scheduler.capacity.maximum-applications: 10000
-  yarn.scheduler.capacity.maximum-am-resource-percent: 0.1
-  yarn.scheduler.capacity.resource-calculator: org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator
-  yarn.scheduler.capacity.root.queues: default
-  yarn.scheduler.capacity.root.default.capacity: 100
-  yarn.scheduler.capacity.root.default.user-limit-factor: 1
-  yarn.scheduler.capacity.root.default.maximum-capacity: 100
-  yarn.scheduler.capacity.root.default.state: RUNNING
-  yarn.scheduler.capacity.root.default.acl_submit_applications: "*"
-  yarn.scheduler.capacity.root.default.acl_administer_queue: "*"
-  yarn.scheduler.capacity.root.default.acl_application_max_priority: "*"
-  yarn.scheduler.capacity.root.default.maximum-application-lifetime: -1
-  yarn.scheduler.capacity.root.default.default-application-lifetime: -1
-  yarn.scheduler.capacity.node-locality-delay: 40
-  yarn.scheduler.capacity.rack-locality-additional-delay: -1
-  yarn.scheduler.capacity.queue-mappings: ""
-  yarn.scheduler.capacity.queue-mappings-override.enable: "false"
-  yarn.scheduler.capacity.per-node-heartbeat.maximum-offswitch-assignments: 1
-  yarn.scheduler.capacity.application.fail-fast: false
-
-# Service restart policies
-hdfs_nn_restart: "no"
-hdfs_dn_restart: "no"
-hdfs_jn_restart: "no"
-hdfs_zkfc_restart: "no"
-yarn_nm_restart: "no"
-yarn_rm_restart: "no"
-yarn_ts_restart: "no"

--- a/roles/hadoop/hdfs/datanode/defaults/main.yml
+++ b/roles/hadoop/hdfs/datanode/defaults/main.yml
@@ -1,0 +1,14 @@
+# Hadoop configuration directories
+hadoop_dn_conf_dir: "{{ hadoop_root_conf_dir }}/conf.dn"
+
+# hdfs-site.xml
+hdfs_site:
+  # foo: override_A
+  dfs.datanode.address: 0.0.0.0:9866
+  dfs.datanode.https.address: 0.0.0.0:9865
+  dfs.datanode.data.dir: "{{ hadoop_hdfs_dir }}/dn"
+  dfs.datanode.kerberos.principal: dn/_HOST@{{ realm }}
+  dfs.datanode.keytab.file: /etc/security/keytabs/dn.service.keytab
+
+# Service restart policies
+hdfs_dn_restart: "no"

--- a/roles/hadoop/hdfs/journalnode/defaults/main.yml
+++ b/roles/hadoop/hdfs/journalnode/defaults/main.yml
@@ -1,0 +1,12 @@
+# Hadoop configuration directories
+hadoop_jn_conf_dir: "{{ hadoop_root_conf_dir }}/conf.jn"
+
+# hdfs-site.xml
+hdfs_site:
+  dfs.journalnode.edits.dir: "{{ hadoop_hdfs_dir }}/jn"
+  dfs.journalnode.rpc-address: 0.0.0.0:8485
+  dfs.journalnode.https-address: 0.0.0.0:8481
+  dfs.journalnode.kerberos.internal.spnego.principal: "HTTP/_HOST@{{ realm }}"
+
+# Service restart policies
+hdfs_jn_restart: "no"

--- a/roles/hadoop/hdfs/namenode/defaults/main.yml
+++ b/roles/hadoop/hdfs/namenode/defaults/main.yml
@@ -1,0 +1,31 @@
+# Hadoop configuration directories
+hadoop_nn_conf_dir: "{{ hadoop_root_conf_dir }}/conf.nn"
+hadoop_zkfc_conf_dir: "{{ hadoop_root_conf_dir }}/conf.zkfc"
+
+# ZKFC options
+hdfs_zkfc_nn_opts: "-Djava.security.auth.login.config={{ hadoop_nn_conf_dir }}/krb5JAASnn.conf"
+
+# hdfs-site.xml
+hdfs_site:
+  # dfs.namenode.https-address: 0.0.0.0:9871
+  dfs.namenode.http-address.mycluster.nn1: "{{ groups['hdfs_nn'][0] | tosit.tdp.access_fqdn(hostvars) }}:9870"
+  dfs.namenode.http-address.mycluster.nn2: "{{ groups['hdfs_nn'][1] | tosit.tdp.access_fqdn(hostvars) }}:9870"
+  dfs.namenode.https-address.mycluster.nn1: "{{ groups['hdfs_nn'][0] | tosit.tdp.access_fqdn(hostvars) }}:9871"
+  dfs.namenode.https-address.mycluster.nn2: "{{ groups['hdfs_nn'][1] | tosit.tdp.access_fqdn(hostvars) }}:9871"
+  dfs.namenode.name.dir: "{{ hadoop_hdfs_dir }}/nn"
+  dfs.namenode.shared.edits.dir: |
+    qjournal://{{ groups['hdfs_jn'] | 
+       map('tosit.tdp.access_fqdn', hostvars) |
+       map('regex_replace', '^(.*)$', '\1:8485') |
+       list |
+       join(';')
+    }}/mycluster
+  dfs.namenode.kerberos.principal: "nn/_HOST@{{ realm }}"
+  dfs.namenode.keytab.file: /etc/security/keytabs/nn.service.keytab
+  dfs.namenode.kerberos.internal.spnego.principal: "HTTP/_HOST@{{ realm }}"
+
+namenode_kerberos_principal: "nn/{{ ansible_fqdn }}@{{ realm }}"
+
+# Service restart policies
+hdfs_nn_restart: "no"
+hdfs_zkfc_restart: "no"

--- a/roles/hadoop/hdfs/ranger/defaults/main.yml
+++ b/roles/hadoop/hdfs/ranger/defaults/main.yml
@@ -1,0 +1,7 @@
+# Ranger HDFS properties
+ranger_hdfs_release: ranger-2.0.1-TDP-0.1.0-SNAPSHOT-hdfs-plugin
+ranger_hdfs_dist_file: "{{ ranger_hdfs_release }}.tar.gz"
+ranger_hdfs_install_dir: "{{ hadoop_root_dir }}/ranger-hdfs-plugin"
+ranger_hdfs_install_properties:
+  POLICY_MGR_URL: "https://{{ groups['ranger_admin'][0] | tosit.tdp.access_fqdn(hostvars) }}:6182"
+  REPOSITORY_NAME: hdfs-tdp

--- a/roles/hadoop/yarn/apptimelineserver/defaults/main.yml
+++ b/roles/hadoop/yarn/apptimelineserver/defaults/main.yml
@@ -1,0 +1,20 @@
+# Hadoop configuration directories
+hadoop_ats_conf_dir: "{{ hadoop_root_conf_dir }}/conf.ats"
+
+# yarn-site.xml
+yarn_site:
+  yarn.timeline-service.enabled: "true"
+  yarn.timeline-service.generic-application-history.enabled: "true"
+  yarn.timeline-service.hostname: "{{ groups['yarn_ats'][0] | tosit.tdp.access_fqdn(hostvars) }}"
+  yarn.timeline-service.address: 0.0.0.0:10200
+  yarn.timeline-service.webapp.https.address: "{{ groups['yarn_ats'][0] | tosit.tdp.access_fqdn(hostvars) }}:8190"
+  yarn.timeline-service.principal: ats/_HOST@{{ realm }}
+  yarn.timeline-service.keytab: /etc/security/keytabs/ats.service.keytab
+  # To enable Kerberos on the ATS UI
+  # yarn.timeline-service.http-authentication.type: kerberos
+  # yarn.timeline-service.http-authentication.kerberos.principal: HTTP/_HOST@{{ realm }}
+  # yarn.timeline-service.http-authentication.kerberos.keytab: /etc/security/keytabs/spnego.service.keytab
+
+# Service restart policies
+yarn_ts_restart: "no"
+

--- a/roles/hadoop/yarn/nodemanager/defaults/main.yml
+++ b/roles/hadoop/yarn/nodemanager/defaults/main.yml
@@ -1,0 +1,42 @@
+# Hadoop configuration directories
+hadoop_nm_conf_dir: "{{ hadoop_root_conf_dir }}/conf.nm"
+
+# yarn-site.xml
+yarn_site:
+  yarn.acl.enable: "true"
+  yarn.admin.acl: yarn
+  yarn.scheduler.minimum-allocation-mb: 1024
+  yarn.scheduler.maximum-allocation-mb: 8192
+  yarn.nodemanager.remote-app-log-dir: "/app-logs"
+  yarn.nodemanager.remote-app-log-dir-suffix : "logs"
+  yarn.nodemanager.local-dirs: /data/yarn/local
+  yarn.nodemanager.log-dirs: /data/yarn/logs
+  yarn.nodemanager.container-executor.class: org.apache.hadoop.yarn.server.nodemanager.LinuxContainerExecutor
+  yarn.nodemanager.linux-container-executor.group: hadoop
+  yarn.nodemanager.aux-services: mapreduce_shuffle
+  yarn.nodemanager.aux-services.mapreduce_shuffle.class: org.apache.hadoop.mapred.ShuffleHandler
+  yarn.nodemanager.address: 0.0.0.0:45454
+  yarn.nodemanager.bind-host: 0.0.0.0
+  yarn.nodemanager.webapp.address: 0.0.0.0:8042
+  yarn.nodemanager.webapp.https.address: 0.0.0.0:8044
+  yarn.nodemanager.recovery.enabled: true
+  yarn.nodemanager.recovery.dir: "{{ hadoop_yarn_dir }}"
+  yarn.nodemanager.resource.cpu-vcores: 8
+  yarn.nodemanager.resource.memory-mb: 8192
+  yarn.nodemanager.principal: "nm/_HOST@{{ realm }}"
+  yarn.nodemanager.keytab: /etc/security/keytabs/nm.service.keytab
+  yarn.nodemanager.webapp.spnego-keytab-file: /etc/security/keytabs/spnego.service.keytab
+  yarn.nodemanager.webapp.spnego-principal: "HTTP/_HOST@{{ realm }}"
+  #yarn.nodemanager.vmem-check-enabled: "false"
+  yarn.nodemanager.vmem-pmem-ratio: 4
+
+# container-executor.cfg
+container_executor:
+  yarn.nodemanager.local-dirs: "{{ yarn_site['yarn.nodemanager.local-dirs'] }}"
+  yarn.nodemanager.log-dirs: "{{ yarn_site['yarn.nodemanager.log-dirs'] }}"
+  yarn.nodemanager.linux-container-executor.group: "{{ hadoop_group }}"
+  banned.users: hdfs,yarn,mapred,bin
+  min.user.id: 1000
+
+# Service restart policies
+yarn_nm_restart: "no"

--- a/roles/hadoop/yarn/ranger/defaults/main.yml
+++ b/roles/hadoop/yarn/ranger/defaults/main.yml
@@ -1,0 +1,7 @@
+# Ranger YARN properties
+ranger_yarn_release: ranger-2.0.1-TDP-0.1.0-SNAPSHOT-yarn-plugin
+ranger_yarn_dist_file: "{{ ranger_yarn_release }}.tar.gz"
+ranger_yarn_install_dir: "{{ hadoop_root_dir }}/ranger-yarn-plugin"
+ranger_yarn_install_properties:
+  POLICY_MGR_URL: "https://{{ groups['ranger_admin'][0] | tosit.tdp.access_fqdn(hostvars) }}:6182"
+  REPOSITORY_NAME: yarn-tdp

--- a/roles/hadoop/yarn/resourcemanager/defaults/main.yml
+++ b/roles/hadoop/yarn/resourcemanager/defaults/main.yml
@@ -1,0 +1,40 @@
+# Hadoop configuration directories
+hadoop_rm_conf_dir: "{{ hadoop_root_conf_dir }}/conf.rm"
+
+# yarn-site.xml
+yarn_site:
+  yarn.resourcemanager.webapp.address.rm1: "{{ groups['yarn_rm'][0] | tosit.tdp.access_fqdn(hostvars) }}:8088"
+  yarn.resourcemanager.webapp.address.rm2: "{{ groups['yarn_rm'][1] | tosit.tdp.access_fqdn(hostvars) }}:8088"
+  yarn.resourcemanager.webapp.https.address.rm1: "{{ groups['yarn_rm'][0] | tosit.tdp.access_fqdn(hostvars) }}:8090"
+  yarn.resourcemanager.webapp.https.address.rm2: "{{ groups['yarn_rm'][1] | tosit.tdp.access_fqdn(hostvars) }}:8090"
+  yarn.resourcemanager.webapp.spnego-keytab-file: /etc/security/keytabs/spnego.service.keytab
+  yarn.resourcemanager.webapp.spnego-principal: "HTTP/_HOST@{{ realm }}"
+  yarn.resourcemanager.system-metrics-publisher.enabled: "true"
+  yarn.resourcemanager.recovery.enabled: "true"
+  yarn.resourcemanager.store.class: "org.apache.hadoop.yarn.server.resourcemanager.recovery.ZKRMStateStore"
+
+# capacity-scheduler.xml
+capacity_scheduler:
+  yarn.scheduler.capacity.maximum-applications: 10000
+  yarn.scheduler.capacity.maximum-am-resource-percent: 0.1
+  yarn.scheduler.capacity.resource-calculator: org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator
+  yarn.scheduler.capacity.root.queues: default
+  yarn.scheduler.capacity.root.default.capacity: 100
+  yarn.scheduler.capacity.root.default.user-limit-factor: 1
+  yarn.scheduler.capacity.root.default.maximum-capacity: 100
+  yarn.scheduler.capacity.root.default.state: RUNNING
+  yarn.scheduler.capacity.root.default.acl_submit_applications: "*"
+  yarn.scheduler.capacity.root.default.acl_administer_queue: "*"
+  yarn.scheduler.capacity.root.default.acl_application_max_priority: "*"
+  yarn.scheduler.capacity.root.default.maximum-application-lifetime: -1
+  yarn.scheduler.capacity.root.default.default-application-lifetime: -1
+  yarn.scheduler.capacity.node-locality-delay: 40
+  yarn.scheduler.capacity.rack-locality-additional-delay: -1
+  yarn.scheduler.capacity.queue-mappings: ""
+  yarn.scheduler.capacity.queue-mappings-override.enable: "false"
+  yarn.scheduler.capacity.per-node-heartbeat.maximum-offswitch-assignments: 1
+  yarn.scheduler.capacity.application.fail-fast: false
+
+# Service restart policies
+yarn_rm_restart: "no"
+


### PR DESCRIPTION
This is a proposal for #82 and #83.

I tried to split the defaults variables to the relevant roles as much as possible. Some need to stay in `common` because they are needed in multiple roles:

# HDFS
- `hdfs_zkfc_opts` needed in common because it's in `hadoop-env.sh`
- `dfs.namenode.rpc-address.mycluster.*` is needed everywhere, else `mycluster` is not resolved
- `dfs.journalnode.kerberos.principal` is needed for HDFS NN formating or else it fails with:
```
192.168.32.14:8485: DestHost:destPort master-02.tdp:8485 , LocalHost:localPort master-01.tdp/192.168.32.13:0. Failed on local exception: java.io.IOException: Couldn't set up IO streams: java.lang.IllegalArgumentException: Failed to specify server's Kerberos principal name
```
- Also adding `dfs.journalnode.kerberos.keytab` for consistency
- `dfs.web.authentication.kerberos.principal` is needed by HDFS JN, else the queries from the Namenode fails with:
```
Caused by: org.apache.hadoop.security.authentication.client.AuthenticationException: Authentication failed, URL: https://master-03.tdp:8481/getJournal?jid=mycluster&segmentTxId=1&storageInfo=-64%3A396117039%3A1642433449012%3ACID-800cd574-cf53-4f69-af4b-274007af80d8&inProgressOk=true&user.name=nn/master-01.tdp@REALM.TDP, status: 403, message: GSSException: Failure unspecified at GSS-API level (Mechanism level: Invalid argument (400) - Cannot find key of appropriate type to decrypt AP REP - AES256 CTS mode with HMAC SHA1-96)
```
- Also adding `dfs.web.authentication.kerberos.keytab` for consistency

# YARN
- `yarn.resourcemanager.ha.*`, `yarn.resourcemanager.cluster-id` and `yarn.resourcemanager.hostname.*` are needed everywhere, else the YARN HA is not resolved:
```
2022-01-18 10:12:36,582 INFO org.apache.hadoop.yarn.client.RMProxy: Connecting to ResourceManager at /0.0.0.0:8031
```
- `yarn.resourcemanager.principal` is needed by YARN NM, else it fails with:
```
2022-01-18 10:20:15,378 INFO org.apache.hadoop.io.retry.RetryInvocationHandler: java.io.IOException: DestHost:destPort master-01.tdp:8031 , LocalHost:localPort worker-01.tdp/192.168.32.10:0. Failed on local exception: java.io.IOException: Couldn't set up IO streams: java.lang.IllegalArgumentException: Failed to specify server's Kerberos principal name, while invoking ResourceTrackerPBClientImpl.registerNodeManager over rm1 after 2 failover attempts. Trying to failover after sleeping for 43979ms.
```
- Also adding `yarn.resourcemanager.keytab` for consistency
