### PR TITLE
all: refactor kerberos principals keytabs and configs

### DIFF
--- a/playbooks/hadoop.yml
+++ b/playbooks/hadoop.yml
@@ -6,6 +6,7 @@
 - import_playbook: yarn_nodemanager_install.yml
 - import_playbook: yarn_resourcemanager_install.yml
 - import_playbook: hadoop_client_install.yml
+- import_playbook: hadoop_kerberos_install.yml
 
 - import_playbook: hdfs_namenode_formatzk.yml
 - import_playbook: hdfs_journalnode_start.yml

--- a/playbooks/hadoop_kerberos_install.yml
+++ b/playbooks/hadoop_kerberos_install.yml
@@ -1,0 +1,3 @@
+---
+- import_playbook: hdfs_kerberos_install.yml
+- import_playbook: yarn_kerberos_install.yml

--- a/playbooks/hbase.yml
+++ b/playbooks/hbase.yml
@@ -3,10 +3,12 @@
 - import_playbook: hbase_regionserver_install.yml
 - import_playbook: hbase_rest_install.yml
 - import_playbook: hbase_client_install.yml
+- import_playbook: hbase_kerberos_install.yml
 - import_playbook: phoenix_coprocessor_install.yml
 - import_playbook: phoenix_client_install.yml
 - import_playbook: phoenix_queryserver_daemon_install.yml
 - import_playbook: phoenix_queryserver_client_install.yml
+- import_playbook: phoenix_kerberos_install.yml
 
 - import_playbook: hbase_hdfs_init.yml
 

--- a/playbooks/hbase_kerberos_install.yml
+++ b/playbooks/hbase_kerberos_install.yml
@@ -1,0 +1,28 @@
+---
+- name: Kerberos HBase Master install
+  hosts: hbase_master
+  tasks:
+    - import_role:
+        name: tosit.tdp.hbase.master
+        tasks_from: kerberos
+
+- name: Kerberos HBase RegionServer install
+  hosts: hbase_rs
+  tasks:
+    - import_role:
+        name: tosit.tdp.hbase.regionserver
+        tasks_from: kerberos
+
+- name: Kerberos HBase Rest install
+  hosts: hbase_rest
+  tasks:
+    - import_role:
+        name: tosit.tdp.hbase.rest
+        tasks_from: kerberos
+
+- name: Kerberos HBase Client install
+  hosts: hbase_client
+  tasks:
+    - import_role:
+        name: tosit.tdp.hbase.client
+        tasks_from: kerberos

--- a/playbooks/hdfs_kerberos_install.yml
+++ b/playbooks/hdfs_kerberos_install.yml
@@ -1,0 +1,28 @@
+---
+- name: Kerberos Namenode install
+  hosts: hdfs_nn
+  tasks:
+    - import_role:
+        name: tosit.tdp.hadoop.hdfs.namenode
+        tasks_from: kerberos
+
+- name: Kerberos Journalnode install
+  hosts: hdfs_jn
+  tasks:
+    - import_role:
+        name: tosit.tdp.hadoop.hdfs.journalnode
+        tasks_from: kerberos
+
+- name: Kerberos Datanode install
+  hosts: hdfs_dn
+  tasks:
+    - import_role:
+        name: tosit.tdp.hadoop.hdfs.datanode
+        tasks_from: kerberos
+
+- name: Kerberos HDFS Client install
+  hosts: hadoop_client
+  tasks:
+    - import_role:
+        name: tosit.tdp.hadoop.client
+        tasks_from: kerberos

--- a/playbooks/hive.yml
+++ b/playbooks/hive.yml
@@ -2,6 +2,7 @@
 - import_playbook: hive_hiveserver2_install.yml
 - import_playbook: hive_tez_install.yml
 - import_playbook: hive_client_install.yml
+- import_playbook: hive_kerberos_install.yml
 
 - import_playbook: hive_hdfs_init.yml
 

--- a/playbooks/hive_kerberos_install.yml
+++ b/playbooks/hive_kerberos_install.yml
@@ -1,0 +1,14 @@
+---
+- name: Kerberos HiveServer2 install
+  hosts: hive_s2
+  tasks:
+    - import_role:
+        name: tosit.tdp.hive.hiveserver2
+        tasks_from: kerberos
+
+- name: Kerberos Hive Client install
+  hosts: hive_client
+  tasks:
+    - import_role:
+        name: tosit.tdp.hive.client
+        tasks_from: kerberos

--- a/playbooks/knox.yml
+++ b/playbooks/knox.yml
@@ -1,3 +1,5 @@
 ---
 - import_playbook: knox_gateway_install.yml
+- import_playbook: knox_kerberos_install.yml
+
 - import_playbook: knox_gateway_start.yml

--- a/playbooks/knox_kerberos_install.yml
+++ b/playbooks/knox_kerberos_install.yml
@@ -1,0 +1,7 @@
+---
+- name: Kerberos Knox install
+  hosts: knox
+  tasks:
+    - import_role:
+        name: tosit.tdp.knox.gateway
+        tasks_from: kerberos

--- a/playbooks/phoenix_kerberos_install.yml
+++ b/playbooks/phoenix_kerberos_install.yml
@@ -1,0 +1,7 @@
+---
+- name: Kerberos Phoenix QueryServer install
+  hosts: phoenix_queryserver_daemon
+  tasks:
+    - import_role:
+        name: tosit.tdp.hbase.phoenix.queryserver.daemon
+        tasks_from: kerberos

--- a/playbooks/ranger.yml
+++ b/playbooks/ranger.yml
@@ -1,6 +1,8 @@
 ---
 - import_playbook: ranger_admin_install.yml
 - import_playbook: ranger_usersync_install.yml
+- import_playbook: ranger_kerberos_install.yml
+
 
 - import_playbook: ranger_admin_start.yml
 - import_playbook: ranger_usersync_start.yml

--- a/playbooks/ranger_kerberos_install.yml
+++ b/playbooks/ranger_kerberos_install.yml
@@ -1,0 +1,15 @@
+---
+- name: Kerberos Ranger Admin install
+  hosts: ranger_admin
+  tasks:
+    - import_role:
+        name: tosit.tdp.ranger.admin
+        tasks_from: kerberos
+
+
+- name: Kerberos Ranger UserSync install
+  hosts: ranger_usersync
+  tasks:
+    - import_role:
+        name: tosit.tdp.ranger.usersync
+        tasks_from: kerberos

--- a/playbooks/spark.yml
+++ b/playbooks/spark.yml
@@ -1,6 +1,7 @@
 ---
 - import_playbook: spark_client_install.yml
 - import_playbook: spark_historyserver_install.yml
+- import_playbook: spark_kerberos_install.yml
 
 - import_playbook: spark_hdfs_init.yml
 

--- a/playbooks/spark_kerberos_install.yml
+++ b/playbooks/spark_kerberos_install.yml
@@ -1,0 +1,15 @@
+---
+- name: Kerberos Spark HistoryServer install
+  hosts: spark_hs
+  tasks:
+    - import_role:
+        name: tosit.tdp.spark.historyserver
+        tasks_from: kerberos
+
+
+- name: Kerberos Client install
+  hosts: spark_client
+  tasks:
+    - import_role:
+        name: tosit.tdp.spark.client
+        tasks_from: kerberos

--- a/playbooks/yarn_kerberos_install.yml
+++ b/playbooks/yarn_kerberos_install.yml
@@ -1,0 +1,28 @@
+---
+- name: Kerberos Resource Manager install
+  hosts: yarn_rm
+  tasks:
+    - import_role:
+        name: tosit.tdp.hadoop.yarn.resourcemanager
+        tasks_from: kerberos
+
+- name: Kerberos Nodemanager install
+  hosts: yarn_nm
+  tasks:
+    - import_role:
+        name: tosit.tdp.hadoop.yarn.nodemanager
+        tasks_from: kerberos
+
+- name: Kerberos AppTimelineServer install
+  hosts: yarn_ats
+  tasks:
+    - import_role:
+        name: tosit.tdp.hadoop.yarn.apptimelineserver
+        tasks_from: kerberos
+
+- name: Kerberos Yarn Client install
+  hosts: hadoop_client
+  tasks:
+    - import_role:
+        name: tosit.tdp.hadoop.client
+        tasks_from: kerberos

--- a/playbooks/zookeeper.yml
+++ b/playbooks/zookeeper.yml
@@ -1,4 +1,5 @@
 ---
 - import_playbook: zookeeper_server_install.yml
+- import_playbook: zookeeper_kerberos_install.yml
 
 - import_playbook: zookeeper_server_start.yml

--- a/playbooks/zookeeper_kerberos_install.yml
+++ b/playbooks/zookeeper_kerberos_install.yml
@@ -1,0 +1,7 @@
+---
+- name: Kerberos Zookeeper Install
+  hosts: zk
+  tasks:
+    - import_role:
+        name: tosit.tdp.zookeeper.server
+        tasks_from: kerberos

--- a/roles/hadoop/client/tasks/kerberos.yml
+++ b/roles/hadoop/client/tasks/kerberos.yml
@@ -1,0 +1,7 @@
+---
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: install
+
+- import_role:
+    name: tosit.tdp.hadoop.common

--- a/roles/hadoop/common/tasks/install.yml
+++ b/roles/hadoop/common/tasks/install.yml
@@ -22,11 +22,6 @@
     path: "{{ hadoop_root_dir }}"
     state: directory
 
-- name: Ensures /etc/security/keytabs exists
-  file:
-    path: "/etc/security/keytabs"
-    state: directory
-
 - name: Extract {{ hadoop_dist_file }}
   unarchive:
     src: "/tmp/{{ hadoop_dist_file }}"

--- a/roles/hadoop/hdfs/datanode/tasks/install.yml
+++ b/roles/hadoop/hdfs/datanode/tasks/install.yml
@@ -81,15 +81,6 @@
     src: ssl-server.xml.j2
     dest: '{{ hadoop_dn_conf_dir }}/ssl-server.xml'
 
-- name: Generate principals and keytabs
-  shell: |
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "addprinc -randkey dn/{{ ansible_fqdn }}"
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "xst -k dn.service.keytab dn/{{ ansible_fqdn }}@{{ realm }}"
-    chown {{ hdfs_user }}:{{ hadoop_group }} dn.service.keytab
-  args:
-    chdir: /etc/security/keytabs
-    creates: /etc/security/keytabs/dn.service.keytab
-
 - name: Convert cert and key to pk12
   shell: |
     openssl pkcs12 \

--- a/roles/hadoop/hdfs/datanode/tasks/kerberos.yml
+++ b/roles/hadoop/hdfs/datanode/tasks/kerberos.yml
@@ -1,0 +1,17 @@
+---
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: install
+
+- import_role:
+    name: tosit.tdp.hadoop.common
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: create_principal_keytab
+  vars:
+    principal: "dn/{{ ansible_fqdn }}"
+    keytab: "dn.service.keytab"
+    user: "{{ hdfs_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "600"

--- a/roles/hadoop/hdfs/journalnode/tasks/install.yml
+++ b/roles/hadoop/hdfs/journalnode/tasks/install.yml
@@ -81,29 +81,6 @@
     src: ssl-server.xml.j2
     dest: '{{ hadoop_jn_conf_dir }}/ssl-server.xml'
 
-- name: Generate principals and keytabs
-  shell: |
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "addprinc -randkey jn/{{ ansible_fqdn }}"
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "xst -k jn.service.keytab jn/{{ ansible_fqdn }}@{{ realm }}"
-    chown {{ hdfs_user }}:{{ hadoop_group }} jn.service.keytab
-  args:
-    chdir: /etc/security/keytabs
-    creates: /etc/security/keytabs/jn.service.keytab
-
-- name: Generate principals and keytabs for spnego
-  shell: |
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "addprinc -randkey HTTP/{{ ansible_fqdn }}"
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "xst -k spnego.service.keytab HTTP/{{ ansible_fqdn }}@{{ realm }}"
-    chown {{ hdfs_user }}:{{ hadoop_group }} spnego.service.keytab
-  args:
-    chdir: /etc/security/keytabs
-    creates: /etc/security/keytabs/spnego.service.keytab
-
-- name: Ensure spnego keytab mode is 640
-  file:
-    path: /etc/security/keytabs/spnego.service.keytab
-    mode: '640'
-
 - name: Convert cert and key to pk12
   shell: |
     openssl pkcs12 \

--- a/roles/hadoop/hdfs/journalnode/tasks/kerberos.yml
+++ b/roles/hadoop/hdfs/journalnode/tasks/kerberos.yml
@@ -1,0 +1,27 @@
+---
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: install
+
+- import_role:
+    name: tosit.tdp.hadoop.common
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: create_principal_keytab
+  vars:
+    principal: "jn/{{ ansible_fqdn }}"
+    keytab: "jn.service.keytab"
+    user: "{{ hdfs_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "600"
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: create_principal_keytab
+  vars:
+    principal: "HTTP/{{ ansible_fqdn }}"
+    keytab: "spnego.service.keytab"
+    user: "{{ hdfs_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "640"

--- a/roles/hadoop/hdfs/namenode/tasks/install.yml
+++ b/roles/hadoop/hdfs/namenode/tasks/install.yml
@@ -55,11 +55,6 @@
     hadoop_pid_dir: "{{ hadoop_hdfs_pid_dir }}"
     hdfs_zkfc_opts: "{{ hdfs_zkfc_nn_opts }}"
 
-- name: Template krb5 jaas
-  template:
-    src: krb5JAASnn.conf.j2
-    dest: '{{ hadoop_nn_conf_dir }}/krb5JAASnn.conf'
-
 - name: Template log4j.properties
   template:
     src: log4j.properties.j2
@@ -96,29 +91,6 @@
   template:
     src: ssl-client.xml.j2
     dest: '{{ hadoop_nn_conf_dir }}/ssl-client.xml'
-
-- name: Generate principals and keytabs
-  shell: |
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "addprinc -randkey nn/{{ ansible_fqdn }}"
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "xst -k nn.service.keytab nn/{{ ansible_fqdn }}@{{ realm }}"
-    chown {{ hdfs_user }}:{{ hadoop_group }} nn.service.keytab
-  args:
-    chdir: /etc/security/keytabs
-    creates: /etc/security/keytabs/nn.service.keytab
-
-- name: Generate principals and keytabs for spnego
-  shell: |
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "addprinc -randkey HTTP/{{ ansible_fqdn }}"
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "xst -k spnego.service.keytab HTTP/{{ ansible_fqdn }}@{{ realm }}"
-    chown {{ hdfs_user }}:{{ hadoop_group }} spnego.service.keytab
-  args:
-    chdir: /etc/security/keytabs
-    creates: /etc/security/keytabs/spnego.service.keytab
-
-- name: Ensure spnego keytab mode is 640
-  file:
-    path: /etc/security/keytabs/spnego.service.keytab
-    mode: '640'
 
 # - name: Format NameNode
 #   shell: /opt/tdp/hadoop/bin/hdfs --config /etc/hadoop/conf.nn namenode -format -nonInteractive

--- a/roles/hadoop/hdfs/namenode/tasks/kerberos.yml
+++ b/roles/hadoop/hdfs/namenode/tasks/kerberos.yml
@@ -1,0 +1,32 @@
+---
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: install
+
+- import_role:
+    name: tosit.tdp.hadoop.common
+
+- name: Template krb5 jaas
+  template:
+    src: krb5JAASnn.conf.j2
+    dest: '{{ hadoop_nn_conf_dir }}/krb5JAASnn.conf'
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: create_principal_keytab
+  vars:
+    principal: "nn/{{ ansible_fqdn }}"
+    keytab: "nn.service.keytab"
+    user: "{{ hdfs_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "600"
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: create_principal_keytab
+  vars:
+    principal: "HTTP/{{ ansible_fqdn }}"
+    keytab: "spnego.service.keytab"
+    user: "{{ hdfs_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "640"

--- a/roles/hadoop/yarn/apptimelineserver/tasks/install.yml
+++ b/roles/hadoop/yarn/apptimelineserver/tasks/install.yml
@@ -79,15 +79,6 @@
     src: ssl-client.xml.j2
     dest: '{{ hadoop_ats_conf_dir }}/ssl-client.xml'
 
-- name: Generate principals and keytabs
-  shell: |
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "addprinc -randkey ats/{{ ansible_fqdn }}"
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "xst -k ats.service.keytab ats/{{ ansible_fqdn }}@{{ realm }}"
-    chown {{ yarn_user }}:{{ hadoop_group }} ats.service.keytab
-  args:
-    chdir: /etc/security/keytabs
-    creates: /etc/security/keytabs/ats.service.keytab
-
 - name: Template YARN Timeline Server service file
   template:
     src: hadoop-yarn-timelineserver.service.j2

--- a/roles/hadoop/yarn/apptimelineserver/tasks/kerberos.yml
+++ b/roles/hadoop/yarn/apptimelineserver/tasks/kerberos.yml
@@ -1,0 +1,17 @@
+---
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: install
+
+- import_role:
+    name: tosit.tdp.hadoop.common
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: create_principal_keytab
+  vars:
+    principal: "ats/{{ ansible_fqdn }}"
+    keytab: "ats.service.keytab"
+    user: "{{ yarn_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "600"

--- a/roles/hadoop/yarn/nodemanager/tasks/install.yml
+++ b/roles/hadoop/yarn/nodemanager/tasks/install.yml
@@ -119,26 +119,3 @@
     owner: root
     group: "{{ hadoop_group }}"
     mode: '6050'
-
-- name: Generate principals and keytabs
-  shell: |
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "addprinc -randkey nm/{{ ansible_fqdn }}"
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "xst -k nm.service.keytab nm/{{ ansible_fqdn }}@{{ realm }}"
-    chown {{ yarn_user }}:{{ hadoop_group }} nm.service.keytab
-  args:
-    chdir: /etc/security/keytabs
-    creates: /etc/security/keytabs/nm.service.keytab
-
-- name: Generate principals and keytabs for spnego
-  shell: |
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "addprinc -randkey HTTP/{{ ansible_fqdn }}"
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "xst -k spnego.service.keytab HTTP/{{ ansible_fqdn }}@{{ realm }}"
-    chown {{ hdfs_user }}:{{ hadoop_group }} spnego.service.keytab
-  args:
-    chdir: /etc/security/keytabs
-    creates: /etc/security/keytabs/spnego.service.keytab
-
-- name: Ensure spnego keytab mode is 640
-  file:
-    path: /etc/security/keytabs/spnego.service.keytab
-    mode: '640'

--- a/roles/hadoop/yarn/nodemanager/tasks/kerberos.yml
+++ b/roles/hadoop/yarn/nodemanager/tasks/kerberos.yml
@@ -1,0 +1,27 @@
+---
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: install
+
+- import_role:
+    name: tosit.tdp.hadoop.common
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: create_principal_keytab
+  vars:
+    principal: "nm/{{ ansible_fqdn }}"
+    keytab: "nm.service.keytab"
+    user: "{{ yarn_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "600"
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: create_principal_keytab
+  vars:
+    principal: "HTTP/{{ ansible_fqdn }}"
+    keytab: "spnego.service.keytab"
+    user: "{{ yarn_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "640"

--- a/roles/hadoop/yarn/resourcemanager/tasks/install.yml
+++ b/roles/hadoop/yarn/resourcemanager/tasks/install.yml
@@ -100,12 +100,3 @@
 #   template:
 #     src: ssl-client.xml.j2
 #     dest: '{{ hadoop_rm_conf_dir }}/ssl-client.xml'
-
-- name: Generate principals and keytabs
-  shell: |
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "addprinc -randkey rm/{{ ansible_fqdn }}"
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "xst -k rm.service.keytab rm/{{ ansible_fqdn }}@{{ realm }}"
-    chown {{ yarn_user }}:{{ hadoop_group }} rm.service.keytab
-  args:
-    chdir: /etc/security/keytabs
-    creates: /etc/security/keytabs/rm.service.keytab

--- a/roles/hadoop/yarn/resourcemanager/tasks/kerberos.yml
+++ b/roles/hadoop/yarn/resourcemanager/tasks/kerberos.yml
@@ -1,0 +1,17 @@
+---
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: install
+
+- import_role:
+    name: tosit.tdp.hadoop.common
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: create_principal_keytab
+  vars:
+    principal: "rm/{{ ansible_fqdn }}"
+    keytab: "rm.service.keytab"
+    user: "{{ yarn_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "600"

--- a/roles/hbase/client/tasks/install.yml
+++ b/roles/hbase/client/tasks/install.yml
@@ -30,11 +30,6 @@
     src: hbase/log4j.properties.j2
     dest: '{{ hbase_client_conf_dir }}/log4j.properties'
 
-- name: Template krb5 JAAS
-  template:
-    src: hbase/krb5JAASClient.conf.j2
-    dest: '{{ hbase_client_conf_dir }}/krb5JAASClient.conf'
-
 - name: Render hbase-site.xml
   template:
     src: hbase/hbase-site.xml.j2

--- a/roles/hbase/client/tasks/kerberos.yml
+++ b/roles/hbase/client/tasks/kerberos.yml
@@ -1,0 +1,12 @@
+---
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: install
+
+- import_role:
+    name: tosit.tdp.hbase.common
+
+- name: Template krb5 JAAS
+  template:
+    src: hbase/krb5JAASClient.conf.j2
+    dest: '{{ hbase_client_conf_dir }}/krb5JAASClient.conf'

--- a/roles/hbase/common/tasks/install_hbase.yml
+++ b/roles/hbase/common/tasks/install_hbase.yml
@@ -14,11 +14,6 @@
     path: "{{ hbase_root_dir }}"
     state: directory
 
-- name: Ensures /etc/security/keytabs exists
-  file:
-    path: "/etc/security/keytabs"
-    state: directory
-
 - name: Extract {{ hbase_dist_file }}
   unarchive:
     src: "/tmp/{{ hbase_dist_file }}"

--- a/roles/hbase/master/tasks/install.yml
+++ b/roles/hbase/master/tasks/install.yml
@@ -35,14 +35,6 @@
     src: hbase/hbase-master.service.j2
     dest: /usr/lib/systemd/system/hbase-master.service
 
-- name: Template krb5 JAAS
-  template:
-    src: hbase/krb5JAASServer.conf.j2
-    dest: '{{ hbase_master_conf_dir }}/krb5JAASServer.conf'
-  vars:
-    hbase_keytab_file: "{{ hbase_site['hbase.master.keytab.file'] }}"
-    hbase_principal: "{{ hbase_master_kerberos_principal }}"
-
 - name: Render hbase-site.xml
   template:
     src: hbase/hbase-site.xml.j2
@@ -64,15 +56,6 @@
     src: /etc/hadoop/conf.nn/hdfs-site.xml
     dest: '{{ hbase_master_conf_dir }}/hdfs-site.xml'
     remote_src: yes
-
-- name: Generate principals and keytabs
-  shell: |
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "addprinc -randkey hbase/{{ ansible_fqdn }}"
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "xst -k hbase.service.keytab hbase/{{ ansible_fqdn }}@{{ realm }}"
-    chown {{ hbase_user }}:{{ hadoop_group }} hbase.service.keytab
-  args:
-    chdir: /etc/security/keytabs
-    creates: /etc/security/keytabs/hbase.service.keytab
 
 - name: Convert cert and key to pk12
   shell: |

--- a/roles/hbase/master/tasks/kerberos.yml
+++ b/roles/hbase/master/tasks/kerberos.yml
@@ -1,0 +1,25 @@
+---
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: install
+
+- import_role:
+    name: tosit.tdp.hbase.common
+
+- name: Template krb5 JAAS
+  template:
+    src: hbase/krb5JAASServer.conf.j2
+    dest: '{{ hbase_master_conf_dir }}/krb5JAASServer.conf'
+  vars:
+    hbase_keytab_file: "{{ hbase_site['hbase.master.keytab.file'] }}"
+    hbase_principal: "{{ hbase_master_kerberos_principal }}"
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: create_principal_keytab
+  vars:
+    principal: "hbase/{{ ansible_fqdn }}"
+    keytab: "hbase.service.keytab"
+    user: "{{ hbase_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "600"

--- a/roles/hbase/phoenix/queryserver/daemon/tasks/install.yml
+++ b/roles/hbase/phoenix/queryserver/daemon/tasks/install.yml
@@ -50,29 +50,6 @@
     dest: '{{ hbase_phoenix_queryserver_daemon_conf_dir }}/core-site.xml'
     remote_src: yes
 
-- name: Generate principals and keytabs
-  shell: |
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "addprinc -randkey phoenixqueryserver/{{ ansible_fqdn }}"
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "xst -k phoenixqueryserver.service.keytab phoenixqueryserver/{{ ansible_fqdn }}@{{ realm }}"
-    chown {{ phoenix_queryserver_user }}:{{ hadoop_group }} phoenixqueryserver.service.keytab
-  args:
-    chdir: /etc/security/keytabs
-    creates: /etc/security/keytabs/phoenixqueryserver.service.keytab
-
-- name: Generate principals and keytabs for spnego
-  shell: |
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "addprinc -randkey HTTP/{{ ansible_fqdn }}"
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "xst -k spnego.service.keytab HTTP/{{ ansible_fqdn }}@{{ realm }}"
-    chown {{ phoenix_queryserver_user }}:{{ hadoop_group }} spnego.service.keytab
-  args:
-    chdir: /etc/security/keytabs
-    creates: /etc/security/keytabs/spnego.service.keytab
-
-- name: Ensure spnego keytab mode is 640
-  file:
-    path: /etc/security/keytabs/spnego.service.keytab
-    mode: '640'
-
 - name: Create directory for pid
   file:
     path: '{{ phoenix_queryserver_pid_dir }}'

--- a/roles/hbase/phoenix/queryserver/daemon/tasks/kerberos.yml
+++ b/roles/hbase/phoenix/queryserver/daemon/tasks/kerberos.yml
@@ -1,0 +1,26 @@
+---
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: install
+
+- import_role:
+    name: tosit.tdp.hbase.common
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: create_principal_keytab
+  vars:
+    principal: "phoenixqueryserver/{{ ansible_fqdn }}"
+    keytab: "phoenixqueryserver.service.keytab"
+    user: "{{ phoenix_queryserver_user }}"
+    group: "{{ hadoop_group }}"
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: create_principal_keytab
+  vars:
+    principal: "HTTP/{{ ansible_fqdn }}"
+    keytab: "spnego.service.keytab"
+    user: "{{ phoenix_queryserver_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "640"

--- a/roles/hbase/regionserver/tasks/install.yml
+++ b/roles/hbase/regionserver/tasks/install.yml
@@ -30,14 +30,6 @@
     src: hbase/log4j.properties.j2
     dest: '{{ hbase_rs_conf_dir }}/log4j.properties'
 
-- name: Template krb5 JAAS
-  template:
-    src: hbase/krb5JAASServer.conf.j2
-    dest: '{{ hbase_rs_conf_dir }}/krb5JAASServer.conf'
-  vars:
-    hbase_keytab_file: "{{ hbase_site['hbase.regionserver.keytab.file'] }}"
-    hbase_principal: "{{ hbase_regionserver_kerberos_principal }}"
-
 - name: Template HBase RegionServer service file
   template:
     src: hbase/hbase-regionserver.service.j2
@@ -64,15 +56,6 @@
     src: /etc/hadoop/conf.dn/hdfs-site.xml
     dest: '{{ hbase_rs_conf_dir }}/hdfs-site.xml'
     remote_src: yes
-
-- name: Generate principals and keytabs
-  shell: |
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "addprinc -randkey hbase/{{ ansible_fqdn }}"
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "xst -k hbase.service.keytab hbase/{{ ansible_fqdn }}@{{ realm }}"
-    chown {{ hbase_user }}:{{ hadoop_group }} hbase.service.keytab
-  args:
-    chdir: /etc/security/keytabs
-    creates: /etc/security/keytabs/hbase.service.keytab
 
 - name: Convert cert and key to pk12
   shell: |

--- a/roles/hbase/regionserver/tasks/kerberos.yml
+++ b/roles/hbase/regionserver/tasks/kerberos.yml
@@ -1,0 +1,25 @@
+---
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: install
+
+- import_role:
+    name: tosit.tdp.hbase.common
+
+- name: Template krb5 JAAS
+  template:
+    src: hbase/krb5JAASServer.conf.j2
+    dest: '{{ hbase_rs_conf_dir }}/krb5JAASServer.conf'
+  vars:
+    hbase_keytab_file: "{{ hbase_site['hbase.regionserver.keytab.file'] }}"
+    hbase_principal: "{{ hbase_regionserver_kerberos_principal }}"
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: create_principal_keytab
+  vars:
+    principal: "hbase/{{ ansible_fqdn }}"
+    keytab: "hbase.service.keytab"
+    user: "{{ hbase_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "600"

--- a/roles/hbase/rest/tasks/install.yml
+++ b/roles/hbase/rest/tasks/install.yml
@@ -35,14 +35,6 @@
     src: hbase/hbase-rest.service.j2
     dest: /usr/lib/systemd/system/hbase-rest.service
 
-- name: Template krb5 JAAS
-  template:
-    src: hbase/krb5JAASServer.conf.j2
-    dest: '{{ hbase_rest_conf_dir }}/krb5JAASServer.conf'
-  vars:
-    hbase_keytab_file: "{{ hbase_site['hbase.rest.keytab.file'] }}"
-    hbase_principal: "{{ hbase_rest_kerberos_principal }}"
-
 - name: Render hbase-site.xml
   template:
     src: hbase/hbase-site.xml.j2
@@ -64,29 +56,6 @@
     src: /etc/hadoop/conf/hdfs-site.xml
     dest: '{{ hbase_rest_conf_dir }}/hdfs-site.xml'
     remote_src: yes
-
-- name: Generate principals and keytabs
-  shell: |
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "addprinc -randkey hbase/{{ ansible_fqdn }}"
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "xst -k hbase.service.keytab hbase/{{ ansible_fqdn }}@{{ realm }}"
-    chown {{ hbase_user }}:{{ hadoop_group }} hbase.service.keytab
-  args:
-    chdir: /etc/security/keytabs
-    creates: /etc/security/keytabs/hbase.service.keytab
-
-- name: Generate principals and keytabs for spnego
-  shell: |
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "addprinc -randkey HTTP/{{ ansible_fqdn }}"
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "xst -k spnego.service.keytab HTTP/{{ ansible_fqdn }}@{{ realm }}"
-    chown {{ hbase_user }}:{{ hadoop_group }} spnego.service.keytab
-  args:
-    chdir: /etc/security/keytabs
-    creates: /etc/security/keytabs/spnego.service.keytab
-
-- name: Ensure spnego keytab mode is 640
-  file:
-    path: /etc/security/keytabs/spnego.service.keytab
-    mode: '640'
 
 - name: Convert cert and key to pk12
   shell: |

--- a/roles/hbase/rest/tasks/kerberos.yml
+++ b/roles/hbase/rest/tasks/kerberos.yml
@@ -1,0 +1,35 @@
+---
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: install
+
+- import_role:
+    name: tosit.tdp.hbase.common
+
+- name: Template krb5 JAAS
+  template:
+    src: hbase/krb5JAASServer.conf.j2
+    dest: '{{ hbase_rest_conf_dir }}/krb5JAASServer.conf'
+  vars:
+    hbase_keytab_file: "{{ hbase_site['hbase.rest.keytab.file'] }}"
+    hbase_principal: "{{ hbase_rest_kerberos_principal }}"
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: create_principal_keytab
+  vars:
+    principal: "hbase/{{ ansible_fqdn }}"
+    keytab: "hbase.service.keytab"
+    user: "{{ hbase_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "600"
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: create_principal_keytab
+  vars:
+    principal: "HTTP/{{ ansible_fqdn }}"
+    keytab: "spnego.service.keytab"
+    user: "{{ hbase_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "640"

--- a/roles/hive/client/tasks/kerberos.yml
+++ b/roles/hive/client/tasks/kerberos.yml
@@ -1,0 +1,7 @@
+---
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: install
+
+- import_role:
+    name: tosit.tdp.hive.common

--- a/roles/hive/hiveserver2/tasks/install.yml
+++ b/roles/hive/hiveserver2/tasks/install.yml
@@ -106,29 +106,6 @@
     mode: '600'
     owner: '{{ hive_user }}'
 
-- name: Generate principals and keytabs
-  shell: |
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "addprinc -randkey hive/{{ ansible_fqdn }}"
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "xst -k hive.service.keytab hive/{{ ansible_fqdn }}@{{ realm }}"
-    chown {{ hive_user }}:{{ hadoop_group }} hive.service.keytab
-  args:
-    chdir: /etc/security/keytabs
-    creates: /etc/security/keytabs/hive.service.keytab
-
-- name: Generate principals and keytabs for spnego
-  shell: |
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "addprinc -randkey HTTP/{{ ansible_fqdn }}"
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "xst -k spnego.service.keytab HTTP/{{ ansible_fqdn }}@{{ realm }}"
-    chown {{ hive_user }}:{{ hadoop_group }} spnego.service.keytab
-  args:
-    chdir: /etc/security/keytabs
-    creates: /etc/security/keytabs/spnego.service.keytab
-
-- name: Ensure spnego keytab mode is 640
-  file:
-    path: /etc/security/keytabs/spnego.service.keytab
-    mode: '640'
-
 - name: Template Hiveserver2 service file
   template:
     src: hive-server2.service.j2

--- a/roles/hive/hiveserver2/tasks/kerberos.yml
+++ b/roles/hive/hiveserver2/tasks/kerberos.yml
@@ -1,0 +1,27 @@
+---
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: install
+
+- import_role:
+    name: tosit.tdp.hive.common
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: create_principal_keytab
+  vars:
+    principal: "hive/{{ ansible_fqdn }}"
+    keytab: "hive.service.keytab"
+    user: "{{ hive_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "600"
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: create_principal_keytab
+  vars:
+    principal: "HTTP/{{ ansible_fqdn }}"
+    keytab: "spnego.service.keytab"
+    user: "{{ hive_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "640"

--- a/roles/knox/common/tasks/install.yml
+++ b/roles/knox/common/tasks/install.yml
@@ -21,11 +21,6 @@
     path: "{{ knox_root_dir }}"
     state: directory
 
-- name: Ensures /etc/security/keytabs exists
-  file:
-    path: "/etc/security/keytabs"
-    state: directory
-
 - name: Extract knox binaries
   unarchive:
     src: "{{ item.src }}"

--- a/roles/knox/gateway/tasks/install.yml
+++ b/roles/knox/gateway/tasks/install.yml
@@ -112,26 +112,6 @@
     src: knox-gateway.service.j2
     dest: /usr/lib/systemd/system/knox-gateway.service
 
-- name: Generate principals and keytabs
-  shell: |
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "addprinc -randkey knox/{{ ansible_fqdn }}"
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "xst -k knox.service.keytab knox/{{ ansible_fqdn }}@{{ realm }}"
-    chown {{ knox_user }}:{{ knox_group }} knox.service.keytab
-  args:
-    chdir: /etc/security/keytabs
-    creates: /etc/security/keytabs/knox.service.keytab
-
-- name: Template Knox Gateway JAAS file
-  template:
-    src: krb5JAASLogin.conf.j2
-    dest: '{{ knox_conf_dir }}/krb5JAASLogin.conf'
-
-- name: Create symbolic link to krb5.conf
-  file:
-    src: /etc/krb5.conf
-    dest: '{{ knox_conf_dir }}/krb5.conf'
-    state: link
-
 - name: Convert cert and key to pk12
   shell: |
     openssl pkcs12 \

--- a/roles/knox/gateway/tasks/kerberos.yml
+++ b/roles/knox/gateway/tasks/kerberos.yml
@@ -1,0 +1,28 @@
+---
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: install
+
+- import_role:
+    name: tosit.tdp.knox.common
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: create_principal_keytab
+  vars:
+    principal: "knox/{{ ansible_fqdn }}"
+    keytab: "knox.service.keytab"
+    user: "{{ knox_user }}"
+    group: "{{ knox_group }}"
+    mode: "600"
+
+- name: Template Knox Gateway JAAS file
+  template:
+    src: krb5JAASLogin.conf.j2
+    dest: '{{ knox_conf_dir }}/krb5JAASLogin.conf'
+
+- name: Create symbolic link to krb5.conf
+  file:
+    src: /etc/krb5.conf
+    dest: '{{ knox_conf_dir }}/krb5.conf'
+    state: link

--- a/roles/ranger/admin/tasks/install.yml
+++ b/roles/ranger/admin/tasks/install.yml
@@ -96,38 +96,6 @@
   args:
     creates: '{{ ranger_truststore_location }}'
 
-- name: Generate principals and keytabs for Ranger Lookup
-  shell: |
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "addprinc -randkey rangerlookup/{{ ansible_fqdn }}"
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "xst -k rangerlookup.service.keytab rangerlookup/{{ ansible_fqdn }}@{{ realm }}"
-    chown {{ ranger_user }}:{{ hadoop_group }} rangerlookup.service.keytab
-  args:
-    chdir: /etc/security/keytabs
-    creates: /etc/security/keytabs/rangerlookup.service.keytab
-
-- name: Generate principals and keytabs for Ranger Admin
-  shell: |
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "addprinc -randkey rangeradmin/{{ ansible_fqdn }}"
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "xst -k rangeradmin.service.keytab rangeradmin/{{ ansible_fqdn }}@{{ realm }}"
-    chown {{ ranger_user }}:{{ hadoop_group }} rangeradmin.service.keytab
-  args:
-    chdir: /etc/security/keytabs
-    creates: /etc/security/keytabs/rangeradmin.service.keytab
-
-- name: Generate principals and keytabs for spnego
-  shell: |
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "addprinc -randkey HTTP/{{ ansible_fqdn }}"
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "xst -k spnego.service.keytab HTTP/{{ ansible_fqdn }}@{{ realm }}"
-    chown {{ ranger_user }}:{{ hadoop_group }} spnego.service.keytab
-  args:
-    chdir: /etc/security/keytabs
-    creates: /etc/security/keytabs/spnego.service.keytab
-
-- name: Ensure spnego keytab mode is 640
-  file:
-    path: /etc/security/keytabs/spnego.service.keytab
-    mode: '640'
-
 - name: Run setup.sh
   shell: |
     export JAVA_HOME=/usr/lib/jvm/jre-1.8.0-openjdk

--- a/roles/ranger/admin/tasks/kerberos.yml
+++ b/roles/ranger/admin/tasks/kerberos.yml
@@ -1,0 +1,37 @@
+---
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: install
+
+- import_role:
+    name: tosit.tdp.ranger.common
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: create_principal_keytab
+  vars:
+    principal: "rangerlookup/{{ ansible_fqdn }}"
+    keytab: "rangerlookup.service.keytab"
+    user: "{{ ranger_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "600"
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: create_principal_keytab
+  vars:
+    principal: "rangeradmin/{{ ansible_fqdn }}"
+    keytab: "rangeradmin.service.keytab"
+    user: "{{ ranger_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "600"
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: create_principal_keytab
+  vars:
+    principal: "HTTP/{{ ansible_fqdn }}"
+    keytab: "spnego.service.keytab"
+    user: "{{ ranger_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "640"

--- a/roles/ranger/usersync/tasks/install.yml
+++ b/roles/ranger/usersync/tasks/install.yml
@@ -91,15 +91,6 @@
   args:
     creates: '{{ ranger_truststore_location }}'
 
-- name: Generate principals and keytabs for Ranger Usersync
-  shell: |
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "addprinc -randkey rangerusersync/{{ ansible_fqdn }}"
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "xst -k rangerusersync.service.keytab rangerusersync/{{ ansible_fqdn }}@{{ realm }}"
-    chown {{ ranger_user }}:{{ hadoop_group }} rangerusersync.service.keytab
-  args:
-    chdir: /etc/security/keytabs
-    creates: /etc/security/keytabs/rangerusersync.service.keytab
-
 - name: Setup usersync
   shell: |
     export JAVA_HOME=/usr/lib/jvm/jre-1.8.0-openjdk

--- a/roles/ranger/usersync/tasks/kerberos.yml
+++ b/roles/ranger/usersync/tasks/kerberos.yml
@@ -1,0 +1,17 @@
+---
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: install
+
+- import_role:
+    name: tosit.tdp.ranger.common
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: create_principal_keytab
+  vars:
+    principal: "rangerusersync/{{ ansible_fqdn }}"
+    keytab: "rangerusersync.service.keytab"
+    user: "{{ ranger_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "600"

--- a/roles/spark/client/tasks/kerberos.yml
+++ b/roles/spark/client/tasks/kerberos.yml
@@ -1,0 +1,7 @@
+---
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: install
+
+- import_role:
+    name: tosit.tdp.spark.common

--- a/roles/spark/historyserver/tasks/install.yml
+++ b/roles/spark/historyserver/tasks/install.yml
@@ -78,30 +78,6 @@
   args:
     creates: '{{ spark_truststore_location }}'
 
-- name: Generate principals and keytabs
-  shell: |
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "addprinc -randkey spark/{{ ansible_fqdn }}"
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "xst -k spark.service.keytab spark/{{ ansible_fqdn }}@{{ realm }}"
-    chown {{ spark_user }}:{{ hadoop_group }} spark.service.keytab
-  args:
-    chdir: /etc/security/keytabs
-    creates: /etc/security/keytabs/spark.service.keytab
-
-- name: Generate principals and keytabs for spnego
-  shell: |
-    cd /etc/security/keytabs
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "addprinc -randkey HTTP/{{ ansible_fqdn }}"
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "xst -k spnego.service.keytab HTTP/{{ ansible_fqdn }}@{{ realm }}"
-    chown {{ spark_user }}:{{ hadoop_group }} spnego.service.keytab
-  args:
-    chdir: /etc/security/keytabs
-    creates: /etc/security/keytabs/spnego.service.keytab
-
-- name: Ensure spnego keytab mode is 640
-  file:
-    path: /etc/security/keytabs/spnego.service.keytab
-    mode: '640'
-
 - name: Template Spark History Server service file
   template:
     src: spark-history-server.service.j2

--- a/roles/spark/historyserver/tasks/kerberos.yml
+++ b/roles/spark/historyserver/tasks/kerberos.yml
@@ -1,0 +1,27 @@
+---
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: install
+
+- import_role:
+    name: tosit.tdp.spark.common
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: create_principal_keytab
+  vars:
+    principal: "spark/{{ ansible_fqdn }}"
+    keytab: "spark.service.keytab"
+    user: "{{ spark_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "600"
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: create_principal_keytab
+  vars:
+    principal: "HTTP/{{ ansible_fqdn }}"
+    keytab: "spnego.service.keytab"
+    user: "{{ spark_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "640"

--- a/roles/utils/kerberos/defaults/main.yaml
+++ b/roles/utils/kerberos/defaults/main.yaml
@@ -1,0 +1,3 @@
+---
+# Keytabs installation directory
+keytabs_dir: "/etc/security/keytabs"

--- a/roles/utils/kerberos/tasks/create_principal_keytab.yml
+++ b/roles/utils/kerberos/tasks/create_principal_keytab.yml
@@ -1,0 +1,10 @@
+---
+- name: Generate principal and keytab for {{ principal }}
+  shell: |
+    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "addprinc -randkey {{ principal }}"
+    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "xst -k {{ keytab }} {{ principal }}@{{ realm }}"
+    chown {{ user }}:{{ group }} {{ keytab }}
+    chmod {{ mode }} {{ keytab }} 
+  args:
+    chdir: "{{ keytabs_dir }}"
+    creates: "{{ keytabs_dir }}/{{ keytab }}"

--- a/roles/utils/kerberos/tasks/install.yml
+++ b/roles/utils/kerberos/tasks/install.yml
@@ -1,0 +1,5 @@
+---
+- name: Ensures {{ keytabs_dir }} exists
+  file:
+    path: "{{ keytabs_dir }}"
+    state: directory

--- a/roles/zookeeper/server/tasks/install.yaml
+++ b/roles/zookeeper/server/tasks/install.yaml
@@ -75,25 +75,6 @@
     src: log4j.properties.j2
     dest: "{{ zookeeper_install_dir }}/conf/log4j.properties"
 
-- name: Ensures /etc/security/keytabs exists
-  file:
-    path: "/etc/security/keytabs"
-    state: directory
-
-- name: Generate principals and keytabs
-  shell: |
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "addprinc -randkey zookeeper/{{ ansible_fqdn }}"
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "xst -k zookeeper.service.keytab zookeeper/{{ ansible_fqdn }}@{{ realm }}"
-    chown {{ zookeeper_user }}:{{ hadoop_group }} zookeeper.service.keytab
-  args:
-    chdir: /etc/security/keytabs
-    creates: /etc/security/keytabs/zookeeper.service.keytab
-
-- name: Template jaas.conf
-  template:
-    src: jaas.conf.j2
-    dest: "{{ zookeeper_install_dir }}/conf/jaas.conf"
-
 - name: Template java.env
   template:
     src: java.env.j2

--- a/roles/zookeeper/server/tasks/kerberos.yml
+++ b/roles/zookeeper/server/tasks/kerberos.yml
@@ -1,0 +1,19 @@
+---
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: install
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: create_principal_keytab
+  vars:
+    principal: "zookeeper/{{ ansible_fqdn }}"
+    keytab: "zookeeper.service.keytab"
+    user: "{{ zookeeper_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "600"
+
+- name: Template jaas.conf
+  template:
+    src: jaas.conf.j2
+    dest: "{{ zookeeper_install_dir }}/conf/jaas.conf"


### PR DESCRIPTION
Fix #54 description:
- `service(s)/component(s)/tasks/kerberos.yml` were added in order to manage all kerberos configs, principals and keytabs
- a new role `roles/utils` was created in order to optimize the usage of common tasks between roles like: kaadmin, user and group creation, etc.
- `service(s)/client/kerberos.yml` were created for all services but not yet implemented with headless keytabs creation