### PR TITLE
kerberos: add Ansible modules for principal and keytab management

### DIFF
--- a/plugins/module_utils/kerberos.py
+++ b/plugins/module_utils/kerberos.py
@@ -11,6 +11,17 @@ kerberos_spec = dict(
 )
 
 
+def get_kinit_cmd(kinit_bin, principal=None, keytab=None, ccache=None):
+    kinit_cmd = [kinit_bin]
+    if principal:
+        kinit_cmd.extend([principal])
+    if keytab:
+        kinit_cmd.extend(['-kt', keytab])
+    if ccache:
+        kinit_cmd.extend(['-c', ccache])
+    return kinit_cmd
+
+
 def kinit(module):
     if not module.params['kerberos']:
         return
@@ -22,18 +33,19 @@ def kinit(module):
     password = module.params['krb_password']
     ccache = module.params['krb_ccache']
 
-    kinit_cmd = [kinit_bin]
-    if principal:
-        kinit_cmd.extend([principal])
-    if keytab:
-        kinit_cmd.extend(['-kt', keytab])
-    if ccache:
-        kinit_cmd.extend(['-c', ccache])
+    kinit_cmd = get_kinit_cmd(kinit_bin, principal, keytab, ccache)
     if password and not keytab:
         module.fail_json(msg='Password authentication not supported for kinit. Use a keytab instead.')
 
     module.run_command(kinit_cmd, check_rc=True)
- 
+
+
+def get_kdestroy_cmd(kdestroy_bin, ccache=None):
+    kdestroy_cmd = [kdestroy_bin]
+    if ccache:
+        kdestroy_cmd.extend(['-c', ccache])
+    return kdestroy_cmd
+
 
 def kdestroy(module):
     if not module.params['kerberos']:
@@ -46,8 +58,6 @@ def kdestroy(module):
     password = module.params['krb_password']
     ccache = module.params['krb_ccache']
 
-    kdestroy_cmd = [kdestroy_bin]
-    if ccache:
-        kdestroy_cmd.extend(['-c', ccache])
+    kdestroy_cmd = get_kdestroy_cmd(kdestroy_bin, ccache)
 
     module.run_command(kdestroy_cmd, check_rc=True)

--- a/plugins/module_utils/kerberos_admin.py
+++ b/plugins/module_utils/kerberos_admin.py
@@ -1,0 +1,28 @@
+#! /usr/bin/env python
+
+kerberos_admin_spec = dict(
+    kadmin_bin=dict(type='path', default='kadmin'),
+    admin_principal=dict(type='str'),
+    admin_password=dict(type='str', no_log=True),
+)
+
+
+def get_kadmin_cmd(kadmin_bin, admin_principal=None, admin_password=None):
+    kadmin_cmd = [kadmin_bin]
+    if admin_principal:
+        kadmin_cmd.extend(['-p', admin_principal])
+    if admin_password:
+        kadmin_cmd.extend(['-w', admin_password])
+    return kadmin_cmd
+
+
+def kadmin(module, args):
+    kadmin_bin = module.params['kadmin_bin']
+    admin_principal = module.params['admin_principal']
+    admin_password = module.params['admin_password']
+
+    kadmin_cmd = get_kadmin_cmd(kadmin_bin, admin_principal, admin_password)
+    kadmin_cmd.extend(args)
+
+    return module.run_command(kadmin_cmd, check_rc=True)
+

--- a/plugins/modules/krb_keytab.py
+++ b/plugins/modules/krb_keytab.py
@@ -1,0 +1,124 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import tempfile
+import shutil
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+from ansible_collections.tosit.tdp.plugins.module_utils.kerberos import get_kinit_cmd, get_kdestroy_cmd
+from ansible_collections.tosit.tdp.plugins.module_utils.kerberos_admin import kerberos_admin_spec, kadmin
+
+def try_kinit(module, kinit_bin, kdestroy_bin, principal, keytab_path):
+    """Try kinit, return True if success, False or exception otherwise"""
+    # Create a tmp dir to store the krb cache in order to not override
+    # an existing cache in default location
+    tmp_dir = tempfile.mkdtemp(suffix='_ansible_module_krb_keytab')
+    try:
+        ccache = os.path.join(tmp_dir, "krb5cc")
+        kinit_cmd = get_kinit_cmd(kinit_bin, principal, keytab_path, ccache)
+        rc, stdout, stderr = module.run_command(kinit_cmd)
+        if rc == 0:
+            kdestroy_cmd = get_kdestroy_cmd(kdestroy_bin, ccache)
+            module.run_command(kdestroy_cmd)
+            return True
+        else:
+            return False
+    finally:
+        shutil.rmtree(tmp_dir)
+
+def main():
+    argument_spec = dict(
+        kinit_bin=dict(type='path', default='kinit'),
+        kdestroy_bin=dict(type='path', default='kdestroy'),
+        principal=dict(type='str', required=True),
+        path=dict(type='path', required=True),
+        state=dict(type='str', choices=['present', 'absent'], default='present'),
+        **kerberos_admin_spec
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        add_file_common_args=True,
+        supports_check_mode=True,
+    )
+
+    kinit_bin = module.params['kinit_bin']
+    kdestroy_bin = module.params['kdestroy_bin']
+    principal = module.params['principal']
+    keytab_path = module.params['path']
+    state = module.params['state']
+
+    try:
+        results = {
+            'changed': False,
+            'diff': {},
+        }
+        current_state = None
+
+        if os.path.isdir(keytab_path):
+            raise RuntimeError("Keytab '{}' is a directory".format(keytab_path))
+
+        if os.path.exists(keytab_path):
+            current_state = 'present'
+        else:
+            current_state = 'absent'
+
+        if current_state == 'absent' and state == 'absent':
+            return module.exit_json(**results)
+
+        if current_state == 'present':
+            # Case when keytab exists and must be remove
+            if state == 'absent':
+                results['changed'] = True
+                if not module.check_mode:
+                    os.remove(keytab_path)
+                return module.exit_json(**results)
+
+            # Case when keytab exists, try kinit to verify if the keytab is working.
+            if try_kinit(module, kinit_bin, kdestroy_bin, principal, keytab_path):
+                # Update file permissions for existing keytab if needed
+                file_args = module.load_file_common_arguments(module.params)
+                results['changed'] = module.set_fs_attributes_if_different(
+                    file_args, results['changed'], results['diff'],
+                )
+
+                return module.exit_json(**results)
+
+        # Either the keytab does not exist or it is not valid, so it must be generated
+        results['changed'] = True
+        if not module.check_mode:
+            rc, stdout, stderr = kadmin(module, ['-q', 'ktadd -k {} {}'.format(keytab_path, principal)])
+            # rc is 0 when the principal does not exist...
+            if 'Principal' in stderr and 'does not exist' in stderr:
+                raise RuntimeError("Failed to generate keytab for principal '{}': {}".format(principal, stderr))
+            # Keytab generated is not guarantee to works so it must be verified,
+            # for example, deleting a principal without deleting the keytab, then create the
+            # same principal will reset the kvno, generate keytab in the same keytab file,
+            # the keytab file will have the old kvno which is greater than the new kvno
+            if not try_kinit(module, kinit_bin, kdestroy_bin, principal, keytab_path):
+                raise RuntimeError("Keytab '{}' generated for principal '{}' is not working".format(keytab_path, principal))
+
+        file_args = module.load_file_common_arguments(module.params)
+
+        # Update the diff dict only if the keytab already exists,
+        # there is no need to display a permission change for a newly created file
+        diff = None
+        if current_state == 'present':
+            diff = results['diff']
+        results['changed'] = module.set_fs_attributes_if_different(
+            file_args, results['changed'], diff,
+        )
+
+        module.exit_json(**results)
+
+    except Exception:
+        import traceback
+        module.fail_json(msg=to_native(traceback.format_exc()))
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/krb_principal.py
+++ b/plugins/modules/krb_principal.py
@@ -1,0 +1,60 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+from ansible_collections.tosit.tdp.plugins.module_utils.kerberos_admin import kerberos_admin_spec, kadmin
+
+def main():
+    argument_spec = dict(
+        principal=dict(type='str', required=True),
+        state=dict(type='str', choices=['present', 'absent'], default='present'),
+        **kerberos_admin_spec
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    principal = module.params['principal']
+    state = module.params['state']
+
+    try:
+        results = {
+            'changed': False,
+        }
+        current_state = None
+
+        rc, stdout, stderr = kadmin(module, ['-q', 'getprinc {}'.format(principal)])
+        if 'Principal does not exist' in stderr:
+            current_state = 'absent'
+        else:
+            current_state = 'present'
+
+        # Case when principal does not exist
+        if current_state == 'absent':
+            if state == 'absent':
+                return module.exit_json(**results)
+            results['changed'] = True
+            if not module.check_mode:
+                kadmin(module, ['-q', 'addprinc -randkey {}'.format(principal)])
+
+        # Case when principal exists and must be remove
+        if current_state == 'present' and state == 'absent':
+            results['changed'] = True
+            if not module.check_mode:
+                kadmin(module, ['-q', 'delprinc -force {}'.format(principal)])
+
+        module.exit_json(**results)
+
+    except Exception:
+        import traceback
+        module.fail_json(msg=to_native(traceback.format_exc()))
+
+if __name__ == '__main__':
+    main()

--- a/roles/utils/kerberos/tasks/create_principal_keytab.yml
+++ b/roles/utils/kerberos/tasks/create_principal_keytab.yml
@@ -1,10 +1,16 @@
 ---
-- name: Generate principal and keytab for {{ principal }}
-  shell: |
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "addprinc -randkey {{ principal }}"
-    kadmin -r {{ realm }} -p {{ kadmin_principal }} -w {{ kadmin_password }} -q "xst -k {{ keytab }} {{ principal }}@{{ realm }}"
-    chown {{ user }}:{{ group }} {{ keytab }}
-    chmod {{ mode }} {{ keytab }} 
-  args:
-    chdir: "{{ keytabs_dir }}"
-    creates: "{{ keytabs_dir }}/{{ keytab }}"
+- name: Create principal for {{ principal }}
+  krb_principal:
+    admin_principal: "{{ kadmin_principal }}"
+    admin_password: "{{ kadmin_password }}"
+    principal: "{{ principal }}"
+
+- name: Generate keytab for {{ principal }}
+  krb_keytab:
+    admin_principal: "{{ kadmin_principal }}"
+    admin_password: "{{ kadmin_password }}"
+    principal: "{{ principal }}"
+    path: "{{ keytabs_dir }}/{{ keytab }}"
+    owner: "{{ user | default(omit) }}"
+    group: "{{ group | default(omit) }}"
+    mode: "{{ mode | default(omit) }}"


### PR DESCRIPTION
- `krb_principal` to manage creation and deletion for principal
- `krb_keytab` to manage creation and deletion for keytab and check
  if the keytab can be use to get a ticket with `kinit`

Use `ktadd` instead of `xst` for creating the keytab. Can not find `xst` in the man page of `kadmin` inside Centos 7 man page.

Fix #96 