### PR TITLE
all: fix spnego keytab owner to use root instead of hdfs, spark, etc.

### DIFF
--- a/roles/hadoop/hdfs/journalnode/tasks/kerberos.yml
+++ b/roles/hadoop/hdfs/journalnode/tasks/kerberos.yml
@@ -22,6 +22,6 @@
   vars:
     principal: "HTTP/{{ ansible_fqdn }}"
     keytab: "spnego.service.keytab"
-    user: "{{ hdfs_user }}"
+    user: "root"
     group: "{{ hadoop_group }}"
     mode: "640"

--- a/roles/hadoop/hdfs/namenode/tasks/kerberos.yml
+++ b/roles/hadoop/hdfs/namenode/tasks/kerberos.yml
@@ -27,6 +27,6 @@
   vars:
     principal: "HTTP/{{ ansible_fqdn }}"
     keytab: "spnego.service.keytab"
-    user: "{{ hdfs_user }}"
+    user: "root"
     group: "{{ hadoop_group }}"
     mode: "640"

--- a/roles/hadoop/yarn/nodemanager/tasks/kerberos.yml
+++ b/roles/hadoop/yarn/nodemanager/tasks/kerberos.yml
@@ -22,6 +22,6 @@
   vars:
     principal: "HTTP/{{ ansible_fqdn }}"
     keytab: "spnego.service.keytab"
-    user: "{{ yarn_user }}"
+    user: "root"
     group: "{{ hadoop_group }}"
     mode: "640"

--- a/roles/hbase/phoenix/queryserver/daemon/tasks/kerberos.yml
+++ b/roles/hbase/phoenix/queryserver/daemon/tasks/kerberos.yml
@@ -21,6 +21,6 @@
   vars:
     principal: "HTTP/{{ ansible_fqdn }}"
     keytab: "spnego.service.keytab"
-    user: "{{ phoenix_queryserver_user }}"
+    user: "root"
     group: "{{ hadoop_group }}"
     mode: "640"

--- a/roles/hbase/rest/tasks/kerberos.yml
+++ b/roles/hbase/rest/tasks/kerberos.yml
@@ -30,6 +30,6 @@
   vars:
     principal: "HTTP/{{ ansible_fqdn }}"
     keytab: "spnego.service.keytab"
-    user: "{{ hbase_user }}"
+    user: "root"
     group: "{{ hadoop_group }}"
     mode: "640"

--- a/roles/hive/hiveserver2/tasks/kerberos.yml
+++ b/roles/hive/hiveserver2/tasks/kerberos.yml
@@ -22,6 +22,6 @@
   vars:
     principal: "HTTP/{{ ansible_fqdn }}"
     keytab: "spnego.service.keytab"
-    user: "{{ hive_user }}"
+    user: "root"
     group: "{{ hadoop_group }}"
     mode: "640"

--- a/roles/ranger/admin/tasks/kerberos.yml
+++ b/roles/ranger/admin/tasks/kerberos.yml
@@ -32,6 +32,6 @@
   vars:
     principal: "HTTP/{{ ansible_fqdn }}"
     keytab: "spnego.service.keytab"
-    user: "{{ ranger_user }}"
+    user: "root"
     group: "{{ hadoop_group }}"
     mode: "640"

--- a/roles/spark/historyserver/tasks/kerberos.yml
+++ b/roles/spark/historyserver/tasks/kerberos.yml
@@ -22,6 +22,6 @@
   vars:
     principal: "HTTP/{{ ansible_fqdn }}"
     keytab: "spnego.service.keytab"
-    user: "{{ spark_user }}"
+    user: "root"
     group: "{{ hadoop_group }}"
     mode: "640"


### PR DESCRIPTION
The spnego keytab is common to all HTTP services on the same host.