### PR TITLE
mapred: add jobhistory for better knox integration

### DIFF
--- a/playbooks/mapred_jobhistoryserver_config.yml
+++ b/playbooks/mapred_jobhistoryserver_config.yml
@@ -1,0 +1,10 @@
+---
+- name: Config Mapred Job History Server
+  hosts: mapred_jhs
+  tasks:
+    - tosit.tdp.resolve:
+        node_name: yarn_jobhistoryserver
+    - import_role:
+        name: tosit.tdp.yarn.jobhistoryserver
+        tasks_from: config
+    - meta: clear_facts

--- a/playbooks/mapred_jobhistoryserver_install.yml
+++ b/playbooks/mapred_jobhistoryserver_install.yml
@@ -1,0 +1,10 @@
+---
+- name: Install Mapred Job History Server
+  hosts: mapred_jhs
+  tasks:
+    - tosit.tdp.resolve:
+        node_name: yarn_jobhistoryserver
+    - import_role:
+        name: tosit.tdp.yarn.jobhistoryserver
+        tasks_from: install
+    - meta: clear_facts

--- a/playbooks/mapred_jobhistoryserver_start.yml
+++ b/playbooks/mapred_jobhistoryserver_start.yml
@@ -1,0 +1,10 @@
+---
+- name: Start Mapred Job History Server
+  hosts: mapred_jhs
+  tasks:
+    - tosit.tdp.resolve:
+        node_name: yarn_jobhistoryserver
+    - import_role:
+        name: tosit.tdp.yarn.jobhistoryserver
+        tasks_from: start
+    - meta: clear_facts

--- a/playbooks/yarn.yml
+++ b/playbooks/yarn.yml
@@ -1,6 +1,8 @@
 ---
 - import_playbook: yarn_apptimelineserver_install.yml
 - import_playbook: yarn_apptimelineserver_config.yml
+- import_playbook: mapred_jobhistoryserver_install.yml
+- import_playbook: mapred_jobhistoryserver_config.yml
 - import_playbook: yarn_nodemanager_install.yml
 - import_playbook: yarn_nodemanager_config.yml
 - import_playbook: yarn_resourcemanager_install.yml
@@ -15,3 +17,5 @@
 - import_playbook: yarn_nodemanager_start.yml
 
 - import_playbook: yarn_hdfs_init.yml
+
+- import_playbook: mapred_jobhistoryserver_start.yml

--- a/playbooks/yarn_kerberos_install.yml
+++ b/playbooks/yarn_kerberos_install.yml
@@ -29,6 +29,16 @@
         name: tosit.tdp.yarn.apptimelineserver
         tasks_from: kerberos
     - meta: clear_facts
+- name: Kerberos Job History Server install
+  hosts: mapred_jhs
+  strategy: linear
+  tasks:
+    - tosit.tdp.resolve:
+        node_name: yarn_kerberos
+    - import_role:
+        name: tosit.tdp.yarn.jobhistoryserver
+        tasks_from: kerberos
+    - meta: clear_facts
 - name: Kerberos Yarn Client install
   hosts: edge[0]
   strategy: linear

--- a/playbooks/yarn_ssl-tls_install.yml
+++ b/playbooks/yarn_ssl-tls_install.yml
@@ -26,6 +26,15 @@
         name: tosit.tdp.yarn.apptimelineserver
         tasks_from: ssl-tls
     - meta: clear_facts
+- name: SSL-TLS Job History Server install
+  hosts: mapred_jhs
+  tasks:
+    - tosit.tdp.resolve:
+        node_name: yarn_ssl-tls
+    - import_role:
+        name: tosit.tdp.yarn.jobhistoryserver
+        tasks_from: ssl-tls
+    - meta: clear_facts    
 - name: SSL-TLS Yarn Client install
   hosts: hadoop_client
   tasks:

--- a/roles/yarn/common/templates/hadoop-mapred-jobhistoryserver.service.j2
+++ b/roles/yarn/common/templates/hadoop-mapred-jobhistoryserver.service.j2
@@ -1,0 +1,15 @@
+[Unit]
+Description=Mapred Job History Server
+
+[Service]
+User={{ mapred_user }}
+Group={{ hadoop_group }}
+PIDFile={{ hadoop_pid_dir }}/mapred/hadoop-mapred-historyserver.pid
+ExecStart={{ hadoop_install_dir }}/bin/mapred --config {{ hadoop_jhs_conf_dir }} --daemon start historyserver
+ExecReload={{ hadoop_install_dir }}/bin/mapred --config {{ hadoop_jhs_conf_dir }} --daemon restart historyserver
+ExecStop={{ hadoop_install_dir }}/bin/mapred --config {{ hadoop_jhs_conf_dir }} --daemon stop historyserver
+LimitNOFILE=64000
+Restart={{ mapred_jhs_restart}}
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/yarn/common/templates/mapred-site.xml.j2
+++ b/roles/yarn/common/templates/mapred-site.xml.j2
@@ -1,0 +1,8 @@
+<configuration>
+  {% for name, value in mapred_site.items() %}
+  <property>
+    <name>{{ name }}</name>
+    <value>{{ value }}</value>
+  </property>
+  {% endfor %}
+</configuration>

--- a/roles/yarn/jobhistoryserver/tasks/config.yml
+++ b/roles/yarn/jobhistoryserver/tasks/config.yml
@@ -1,0 +1,46 @@
+---
+- name: Backup configuration
+  copy:
+    src: '{{ hadoop_jhs_conf_dir }}/'
+    dest: '{{ hadoop_jhs_conf_dir }}.{{ ansible_date_time.epoch }}'
+    group: '{{ hadoop_group }}'
+    owner: '{{ hdfs_user }}'
+    remote_src: yes
+  tags:
+    - backup
+
+- name: Template hadoop-env.sh
+  template:
+    src: hadoop-env.sh.j2
+    dest: '{{ hadoop_jhs_conf_dir }}/hadoop-env.sh'
+  vars:
+    hadoop_log_dir: "{{ hadoop_mapred_log_dir }}"
+    hadoop_pid_dir: "{{ hadoop_mapred_pid_dir }}"
+
+- name: Template log4j.properties
+  template:
+    src: log4j.properties.j2
+    dest: '{{ hadoop_jhs_conf_dir }}/log4j.properties'
+  vars:
+    hadoop_log_dir: "{{ hadoop_mapred_log_dir }}"
+
+- name: Render core-site.xml
+  template:
+    src: core-site.xml.j2
+    dest: '{{ hadoop_jhs_conf_dir }}/core-site.xml'
+
+- name: Copy hdfs-site.xml
+  copy:
+    src: /etc/hadoop/conf/hdfs-site.xml
+    dest: '{{ hadoop_jhs_conf_dir }}/hdfs-site.xml'
+    remote_src: yes
+
+- name: Render yarn-site.xml
+  template:
+    src: yarn-site.xml.j2
+    dest: '{{ hadoop_jhs_conf_dir }}/yarn-site.xml'
+
+- name: Render mapred-site.xml
+  template:
+    src: mapred-site.xml.j2
+    dest: '{{ hadoop_jhs_conf_dir }}/mapred-site.xml'

--- a/roles/yarn/jobhistoryserver/tasks/install.yml
+++ b/roles/yarn/jobhistoryserver/tasks/install.yml
@@ -1,0 +1,35 @@
+---
+- import_role:
+    name: tosit.tdp.hadoop.common
+    tasks_from: install
+
+- name: Create directory for pid
+  file:
+    path: '{{ hadoop_mapred_pid_dir }}'
+    state: directory
+    group: '{{ hadoop_group }}'
+    owner: '{{ mapred_user }}'
+
+- name: Template hadoop yarn tmpfiles.d
+  template:
+    src: tmpfiles-hadoop-yarn.conf.j2
+    dest: /etc/tmpfiles.d/hadoop-yarn.conf
+
+- name: Create log directory
+  file:
+    path: '{{ hadoop_mapred_log_dir }}'
+    state: directory
+    group: '{{ hadoop_group }}'
+    owner: '{{ mapred_user }}'
+
+- name: Create configuration directory
+  file:
+    path: '{{ hadoop_jhs_conf_dir }}'
+    state: directory
+    group: '{{ hadoop_group }}'
+    owner: '{{ mapred_user }}'
+
+- name: Template Mapred History Server service file
+  template:
+    src: hadoop-mapred-jobhistoryserver.service.j2
+    dest: /usr/lib/systemd/system/hadoop-mapred-jobhistoryserver.service

--- a/roles/yarn/jobhistoryserver/tasks/kerberos.yml
+++ b/roles/yarn/jobhistoryserver/tasks/kerberos.yml
@@ -1,0 +1,14 @@
+---
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: install
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: create_principal_keytab
+  vars:
+    principal: "jhs/{{ ansible_fqdn }}"
+    keytab: "jhs.service.keytab"
+    user: "{{ mapred_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "600"

--- a/roles/yarn/jobhistoryserver/tasks/ssl-tls.yml
+++ b/roles/yarn/jobhistoryserver/tasks/ssl-tls.yml
@@ -1,0 +1,24 @@
+---
+- name: Render ssl-server.xml
+  template:
+    src: ssl-server.xml.j2
+    dest: '{{ hadoop_jhs_conf_dir }}/ssl-server.xml'
+
+- name: Render ssl-client.xml
+  template:
+    src: ssl-client.xml.j2
+    dest: '{{ hadoop_jhs_conf_dir }}/ssl-client.xml'
+
+- include_role:
+    name: tosit.tdp.utils.ssl_tls
+    tasks_from: create_keystore
+  vars:
+    keystore_location: "{{ hadoop_keystore_location }}"
+    keystore_password: "{{ hadoop_keystore_password }}"
+
+- include_role:
+    name: tosit.tdp.utils.ssl_tls
+    tasks_from: create_truststore
+  vars:
+    truststore_location: "{{ hadoop_truststore_location }}"
+    truststore_password: "{{ hadoop_truststore_password }}"

--- a/roles/yarn/jobhistoryserver/tasks/start.yml
+++ b/roles/yarn/jobhistoryserver/tasks/start.yml
@@ -1,0 +1,6 @@
+---
+- name: Start Mapred History Server
+  service:
+    name: hadoop-mapred-jobhistoryserver
+    state: started
+    enabled: yes

--- a/roles/yarn/jobhistoryserver/templates
+++ b/roles/yarn/jobhistoryserver/templates
@@ -1,0 +1,1 @@
+../common/templates

--- a/roles/yarn/resourcemanager/tasks/config.yml
+++ b/roles/yarn/resourcemanager/tasks/config.yml
@@ -40,6 +40,11 @@
     src: yarn-site.xml.j2
     dest: '{{ hadoop_rm_conf_dir }}/yarn-site.xml'
 
+- name: Render mapred-site.xml
+  template:
+    src: mapred-site.xml.j2
+    dest: '{{ hadoop_rm_conf_dir }}/mapred-site.xml'
+
 - name: Render capacity-scheduler.xml
   template:
     src: capacity-scheduler.xml.j2

--- a/tdp_vars_defaults/hadoop/hadoop.yml
+++ b/tdp_vars_defaults/hadoop/hadoop.yml
@@ -21,6 +21,7 @@ hadoop_client_conf_dir: "{{ hadoop_root_conf_dir }}/conf"
 hadoop_rm_conf_dir: "{{ hadoop_root_conf_dir }}/conf.rm"
 hadoop_nm_conf_dir: "{{ hadoop_root_conf_dir }}/conf.nm"
 hadoop_ats_conf_dir: "{{ hadoop_root_conf_dir }}/conf.ats"
+hadoop_jhs_conf_dir: "{{ hadoop_root_conf_dir }}/conf.jhs"
 
 # Hadoop pid directories
 hadoop_pid_dir: /run/hadoop
@@ -109,4 +110,18 @@ mapred_site:
   mapreduce.map.java.opts: -Xmx768m
   mapreduce.reduce.java.opts: -Xmx1536m
   mapreduce.application.classpath: /opt/tdp/hadoop/share/hadoop/mapreduce/*,/opt/tdp/hadoop/share/hadoop/mapreduce/lib/*,/etc/hadoop/conf/
-  mapreduce.jobhistory.address: "{{ groups['yarn_ats'][0] | tosit.tdp.access_fqdn(hostvars) }}:10200"
+  # jobhistory conf
+  mapreduce.jobhistory.address: "{{ groups['mapred_jhs'][0] | tosit.tdp.access_fqdn(hostvars) }}:10201"
+  mapreduce.jobhistory.webapp.address: "{{ groups['mapred_jhs'][0] | tosit.tdp.access_fqdn(hostvars) }}:19888"
+  mapreduce.jobhistory.webapp.https.address: "{{ groups['mapred_jhs'][0] | tosit.tdp.access_fqdn(hostvars) }}:19890"
+  mapreduce.jobhistory.intermediate-done-dir: /mr-history/tmp
+  mapreduce.jobhistory.done-dir: /mr-history/done
+  mapreduce.jobhistory.principal: jhs/_HOST@{{ realm }}
+  mapreduce.jobhistory.keytab: /etc/security/keytabs/jhs.service.keytab
+  mapreduce.jobhistory.bind-host: 0.0.0.0
+  mapreduce.cluster.acls.enabled: true
+  mapreduce.cluster.administrators: mapred,yarn,knox 
+  mapreduce.jobhistory.admin.acl: "*" 
+  mapreduce.jobhistory.http.policy: HTTPS_ONLY
+  mapreduce.jobhistory.webapp.spnego-principal: HTTP/_HOST@{{ realm }} 
+  mapreduce.jobhistory.webapp.spnego-keytab-file: /etc/security/keytabs/spnego.service.keytab

--- a/tdp_vars_defaults/knox/knox.yml
+++ b/tdp_vars_defaults/knox/knox.yml
@@ -92,6 +92,10 @@ gateway_topology:
           - "{{ groups['hdfs_nn'] | map('tosit.tdp.access_fqdn', hostvars) | first }}"
         port: 9871
         version: 2.7.0
+      JOBHISTORYUI:
+        hosts:
+          - "{{ groups['mapred_jhs'] | map('tosit.tdp.access_fqdn', hostvars) | first }}"
+        port: 19890
       HIVE: {}
       RANGERUI:
         hosts: "{{ groups['ranger_admin'] | map('tosit.tdp.access_fqdn', hostvars) | list }}"

--- a/tdp_vars_defaults/yarn/yarn.yml
+++ b/tdp_vars_defaults/yarn/yarn.yml
@@ -5,7 +5,11 @@ hadoop_yarn_dir: /var/lib/yarn
 hadoop_yarn_pid_dir: /run/hadoop/yarn
 hadoop_yarn_log_dir: /var/log/hadoop/yarn
 
-# Properties
+hadoop_mapred_dir: /var/lib/mapred
+hadoop_mapred_pid_dir: /run/hadoop/mapred
+hadoop_mapred_log_dir: /var/log/hadoop/mapred
+
+# Propertiess
 hdfs_user: hdfs
 
 # TODO: make a yarn_site per service: rm, nm, ts
@@ -68,7 +72,8 @@ yarn_site:
   # yarn.timeline-service.http-authentication.kerberos.principal: HTTP/_HOST@{{ realm }}
   # yarn.timeline-service.http-authentication.kerberos.keytab: /etc/security/keytabs/spnego.service.keytab
   yarn.acl.enable: "true"
-  yarn.admin.acl: yarn
+  yarn.admin.acl: yarn,knox
+  yarn.log.server.url: "https://{{ groups['mapred_jhs'][0] | tosit.tdp.access_fqdn(hostvars) }}:19890/jobhistory/logs"
 
 # container-executor.cfg
 container_executor:
@@ -111,3 +116,4 @@ capacity_scheduler:
 yarn_nm_restart: "no"
 yarn_rm_restart: "no"
 yarn_ts_restart: "no"
+mapred_jhs_restart: "no"


### PR DESCRIPTION
Fix #144 and  #117 description:

-  `Mapred JobHistoryServer` is deployed via a new role and integrated to `knox`
-   thanks to this integration, all logs are accessible now via yarn-ui (not only mapreduce)
-   actually, impersonation is not supported by jobhistory, so, knox user is used for logs access as **admin**
-   think to add the `mapred_jhs` node in your topology for the deployment

Now, you can navigate via `https://<gateway-address>/gateway/tdpldap/yarn` and `https://<gateway-address>/gateway/tdpldap/historyserver` without any issue.