### PR TITLE
hive: move "hadoop credential create" from "install" to "config"

### DIFF
--- a/roles/hive/hiveserver2/tasks/config.yml
+++ b/roles/hive/hiveserver2/tasks/config.yml
@@ -9,6 +9,18 @@
   tags:
     - backup
 
+- name: Create hive credentials store
+  shell: |
+    {{ hadoop_home }}/bin/hadoop credential create javax.jdo.option.ConnectionPassword -value {{ hive_ms_db_password }} -provider {{ hive_ms_credentials_store_uri }}
+  args:
+    creates: '{{ hive_ms_credentials_store_path }}'
+
+- name: Ensure hive credentials store is 600 and owned by hive
+  file:
+    path: '{{ hive_ms_credentials_store_path }}'
+    mode: '600'
+    owner: '{{ hive_user }}'
+
 - name: Template hive-env.sh
   template:
     src: hive-env.sh.j2

--- a/roles/hive/hiveserver2/tasks/install.yml
+++ b/roles/hive/hiveserver2/tasks/install.yml
@@ -21,18 +21,6 @@
     group: '{{ hadoop_group }}'
     owner: '{{ hive_user }}'
 
-- name: Create hive credentials store
-  shell: |
-    {{ hadoop_home }}/bin/hadoop credential create javax.jdo.option.ConnectionPassword -value {{ hive_ms_db_password }} -provider {{ hive_ms_credentials_store_uri }}
-  args:
-    creates: '{{ hive_ms_credentials_store_path }}'
-
-- name: Ensure hive credentials store is 600 and owned by hive
-  file:
-    path: '{{ hive_ms_credentials_store_path }}'
-    mode: '600'
-    owner: '{{ hive_user }}'
-
 - name: Template Hiveserver2 service file
   template:
     src: hive-server2.service.j2


### PR DESCRIPTION
Fix #175.

`hadoop credential create` need `hadoop-env.sh` which is done via `hadoop_client_config`.