### PR TITLE
all: systemd, add SuccessExitStatus and remove ExecReload

### DIFF
--- a/roles/hbase/common/templates/hbase/hbase-master.service.j2
+++ b/roles/hbase/common/templates/hbase/hbase-master.service.j2
@@ -4,12 +4,13 @@ Description=HBase Master
 [Service]
 User={{ hbase_user }}
 Group={{ hadoop_group }}
+Type=forking
 PIDFile={{ hbase_pid_dir }}/hbase-hbase-master.pid
-ExecStart={{ hbase_install_dir }}/bin/hbase-daemon.sh --config {{ hbase_master_conf_dir }} foreground_start master
-ExecReload={{ hbase_install_dir }}/bin/hbase-daemon.sh --config {{ hbase_master_conf_dir }} restart master
+ExecStart={{ hbase_install_dir }}/bin/hbase-daemon.sh --config {{ hbase_master_conf_dir }} start master
 ExecStop={{ hbase_install_dir }}/bin/hbase-daemon.sh --config {{ hbase_master_conf_dir }} stop master
+SuccessExitStatus=143
 LimitNOFILE=64000
-Restart={{ hbase_master_restart}}
+Restart={{ hbase_master_restart }}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/hbase/common/templates/hbase/hbase-regionserver.service.j2
+++ b/roles/hbase/common/templates/hbase/hbase-regionserver.service.j2
@@ -4,12 +4,13 @@ Description=HBase RegionServer
 [Service]
 User={{ hbase_user }}
 Group={{ hadoop_group }}
-PIDFile={{ hbase_pid_dir }}/hbase-hbase-master.pid
-ExecStart={{ hbase_install_dir }}/bin/hbase-daemon.sh --config {{ hbase_rs_conf_dir }} foreground_start regionserver
-ExecReload={{ hbase_install_dir }}/bin/hbase-daemon.sh --config {{ hbase_rs_conf_dir }} restart regionserver
+Type=forking
+PIDFile={{ hbase_pid_dir }}/hbase-hbase-regionserver.pid
+ExecStart={{ hbase_install_dir }}/bin/hbase-daemon.sh --config {{ hbase_rs_conf_dir }} start regionserver
 ExecStop={{ hbase_install_dir }}/bin/hbase-daemon.sh --config {{ hbase_rs_conf_dir }} stop regionserver
+SuccessExitStatus=143
 LimitNOFILE=64000
-Restart={{ hbase_rs_restart}}
+Restart={{ hbase_rs_restart }}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/hbase/common/templates/hbase/hbase-rest.service.j2
+++ b/roles/hbase/common/templates/hbase/hbase-rest.service.j2
@@ -4,12 +4,13 @@ Description=HBase REST
 [Service]
 User={{ hbase_user }}
 Group={{ hadoop_group }}
+Type=forking
 PIDFile={{ hbase_pid_dir }}/hbase-hbase-rest.pid
-ExecStart={{ hbase_install_dir }}/bin/hbase-daemon.sh --config {{ hbase_rest_conf_dir }} foreground_start rest
-ExecReload={{ hbase_install_dir }}/bin/hbase-daemon.sh --config {{ hbase_rest_conf_dir }} restart rest
+ExecStart={{ hbase_install_dir }}/bin/hbase-daemon.sh --config {{ hbase_rest_conf_dir }} start rest
 ExecStop={{ hbase_install_dir }}/bin/hbase-daemon.sh --config {{ hbase_rest_conf_dir }} stop rest
+SuccessExitStatus=143
 LimitNOFILE=64000
-Restart={{ hbase_rest_restart}}
+Restart={{ hbase_rest_restart }}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/hbase/common/templates/phoenix_queryserver/phoenix-queryserver.service.j2
+++ b/roles/hbase/common/templates/phoenix_queryserver/phoenix-queryserver.service.j2
@@ -8,7 +8,7 @@ PIDFile={{ phoenix_queryserver_pid_dir }}/phoenix-{{ phoenix_queryserver_user }}
 ExecStart={{ phoenix_queryserver_install_dir }}/bin/queryserver.py start
 ExecStop={{ phoenix_queryserver_install_dir }}/bin/queryserver.py stop
 LimitNOFILE=64000
-Restart={{ phoenix_queryserver_restart}}
+Restart={{ phoenix_queryserver_restart }}
 Environment="HBASE_CONF_DIR={{ hbase_phoenix_queryserver_daemon_conf_dir }}"
 
 [Install]

--- a/roles/hdfs/common/templates/hadoop-hdfs-datanode.service.j2
+++ b/roles/hdfs/common/templates/hadoop-hdfs-datanode.service.j2
@@ -4,12 +4,13 @@ Description=HDFS DataNode
 [Service]
 User={{ hdfs_user }}
 Group={{ hadoop_group }}
+Type=forking
 PIDFile={{ hadoop_hdfs_pid_dir }}/hadoop-hdfs-datanode.pid
 ExecStart={{ hadoop_install_dir }}/bin/hdfs --config {{ hadoop_dn_conf_dir }} --daemon start datanode
-ExecReload={{ hadoop_install_dir }}/bin/hdfs --config {{ hadoop_dn_conf_dir }} --daemon restart datanode
 ExecStop={{ hadoop_install_dir }}/bin/hdfs --config {{ hadoop_dn_conf_dir }} --daemon stop datanode
+SuccessExitStatus=143
 LimitNOFILE=64000
-Restart={{ hdfs_dn_restart}}
+Restart={{ hdfs_dn_restart }}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/hdfs/common/templates/hadoop-hdfs-journalnode.service.j2
+++ b/roles/hdfs/common/templates/hadoop-hdfs-journalnode.service.j2
@@ -4,12 +4,13 @@ Description=HDFS JournalNode
 [Service]
 User={{ hdfs_user }}
 Group={{ hadoop_group }}
+Type=forking
 PIDFile={{ hadoop_hdfs_pid_dir }}/hadoop-hdfs-journalnode.pid
 ExecStart={{ hadoop_install_dir }}/bin/hdfs --config {{ hadoop_jn_conf_dir }} --daemon start journalnode
-ExecReload={{ hadoop_install_dir }}/bin/hdfs --config {{ hadoop_jn_conf_dir }} --daemon restart journalnode
 ExecStop={{ hadoop_install_dir }}/bin/hdfs --config {{ hadoop_jn_conf_dir }} --daemon stop journalnode
+SuccessExitStatus=143
 LimitNOFILE=64000
-Restart={{ hdfs_jn_restart}}
+Restart={{ hdfs_jn_restart }}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/hdfs/common/templates/hadoop-hdfs-namenode.service.j2
+++ b/roles/hdfs/common/templates/hadoop-hdfs-namenode.service.j2
@@ -4,12 +4,13 @@ Description=HDFS NameNode
 [Service]
 User={{ hdfs_user }}
 Group={{ hadoop_group }}
+Type=forking
 PIDFile={{ hadoop_hdfs_pid_dir }}/hadoop-hdfs-namenode.pid
 ExecStart={{ hadoop_install_dir }}/bin/hdfs --config {{ hadoop_nn_conf_dir }} --daemon start namenode
-ExecReload={{ hadoop_install_dir }}/bin/hdfs --config {{ hadoop_nn_conf_dir }} --daemon restart namenode
 ExecStop={{ hadoop_install_dir }}/bin/hdfs --config {{ hadoop_nn_conf_dir }} --daemon stop namenode
+SuccessExitStatus=143
 LimitNOFILE=64000
-Restart={{ hdfs_nn_restart}}
+Restart={{ hdfs_nn_restart }}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/hdfs/common/templates/hadoop-hdfs-zkfc.service.j2
+++ b/roles/hdfs/common/templates/hadoop-hdfs-zkfc.service.j2
@@ -4,12 +4,13 @@ Description=HDFS ZooKeeper Failover Controler
 [Service]
 User={{ hdfs_user }}
 Group={{ hadoop_group }}
+Type=forking
 PIDFile={{ hadoop_hdfs_pid_dir }}/hadoop-hdfs-zkfc.pid
 ExecStart={{ hadoop_install_dir }}/bin/hdfs --config {{ hadoop_nn_conf_dir }} --daemon start zkfc
-ExecReload={{ hadoop_install_dir }}/bin/hdfs --config {{ hadoop_nn_conf_dir }} --daemon restart zkfc
 ExecStop={{ hadoop_install_dir }}/bin/hdfs --config {{ hadoop_nn_conf_dir }} --daemon stop zkfc
+SuccessExitStatus=143
 LimitNOFILE=64000
-Restart={{ hdfs_zkfc_restart}}
+Restart={{ hdfs_zkfc_restart }}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/hive/common/templates/hive-server2.service.j2
+++ b/roles/hive/common/templates/hive-server2.service.j2
@@ -6,6 +6,7 @@ User={{ hive_user }}
 Group={{ hadoop_group }}
 PIDFile={{ hive_pid_dir }}/hiveserver2.pid
 ExecStart={{ hive_install_dir }}/bin/hive --config {{ hive_s2_conf_dir }} --service hiveserver2 > {{ hive_log_dir }}/hiveserver2.out 2> {{ hive_log_dir }}/hiveserver2.err && echo $!|cat > {{ hive_pid_dir }}/hiveserver2.pid
+SuccessExitStatus=143
 LimitNOFILE=64000
 Restart={{ hiveserver2_restart }}
 

--- a/roles/knox/common/templates/knox-gateway.service.j2
+++ b/roles/knox/common/templates/knox-gateway.service.j2
@@ -9,6 +9,7 @@ PIDFile={{ knox_pid_dir }}/gateway.pid
 Environment="ENV_PID_DIR={{ knox_pid_dir }}"
 ExecStart={{ knox_install_dir }}/bin/gateway.sh start --config /etc/knox/conf/ -Djavax.net.ssl.trustStrore={{ knox_keystore_dir }}/truststore.jks
 ExecStop={{ knox_install_dir }}/bin/gateway.sh stop
+SuccessExitStatus=143
 LimitNOFILE=64000
 Restart={{ knox_restart }}
 

--- a/roles/ranger/common/templates/ranger-admin.service.j2
+++ b/roles/ranger/common/templates/ranger-admin.service.j2
@@ -4,9 +4,9 @@ Description=Ranger Admin
 [Service]
 User={{ ranger_user }}
 Group={{ hadoop_group }}
+Type=forking
 PIDFile={{ ranger_pid_dir }}/rangeradmin.pid
 ExecStart=/usr/bin/ranger-admin start
-ExecReload=/usr/bin/ranger-admin restart
 ExecStop=/usr/bin/ranger-admin stop
 LimitNOFILE=64000
 Restart={{ ranger_admin_restart }}

--- a/roles/ranger/common/templates/ranger-usersync.service.j2
+++ b/roles/ranger/common/templates/ranger-usersync.service.j2
@@ -4,10 +4,11 @@ Description=Ranger Usersync
 [Service]
 User={{ ranger_user }}
 Group={{ hadoop_group }}
+Type=forking
 PIDFile={{ ranger_usersync_pid_dir }}/usersync.pid
 ExecStart=/usr/bin/ranger-usersync start
-ExecReload=/usr/bin/ranger-usersync restart
 ExecStop=/usr/bin/ranger-usersync stop
+SuccessExitStatus=143
 LimitNOFILE=64000
 Restart={{ ranger_usync_restart }}
 

--- a/roles/spark/common/templates/spark-history-server.service.j2
+++ b/roles/spark/common/templates/spark-history-server.service.j2
@@ -9,6 +9,7 @@ Environment="SPARK_PID_DIR={{ spark_pid_dir }}"
 Environment="SPARK_CONF_DIR={{ spark_hs_conf_dir }}"
 ExecStart={{ spark_install_dir }}/sbin/start-history-server.sh
 ExecStop={{ spark_install_dir }}/sbin/stop-history-server.sh
+
 LimitNOFILE=64000
 Restart={{ spark_hs_restart }}
 

--- a/roles/yarn/common/templates/hadoop-mapred-jobhistoryserver.service.j2
+++ b/roles/yarn/common/templates/hadoop-mapred-jobhistoryserver.service.j2
@@ -4,12 +4,13 @@ Description=Mapred Job History Server
 [Service]
 User={{ mapred_user }}
 Group={{ hadoop_group }}
+Type=forking
 PIDFile={{ hadoop_pid_dir }}/mapred/hadoop-mapred-historyserver.pid
 ExecStart={{ hadoop_install_dir }}/bin/mapred --config {{ hadoop_jhs_conf_dir }} --daemon start historyserver
-ExecReload={{ hadoop_install_dir }}/bin/mapred --config {{ hadoop_jhs_conf_dir }} --daemon restart historyserver
 ExecStop={{ hadoop_install_dir }}/bin/mapred --config {{ hadoop_jhs_conf_dir }} --daemon stop historyserver
+SuccessExitStatus=143
 LimitNOFILE=64000
-Restart={{ mapred_jhs_restart}}
+Restart={{ mapred_jhs_restart }}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/yarn/common/templates/hadoop-yarn-nodemanager.service.j2
+++ b/roles/yarn/common/templates/hadoop-yarn-nodemanager.service.j2
@@ -4,12 +4,13 @@ Description=Yarn NodeManager
 [Service]
 User={{ yarn_user }}
 Group={{ hadoop_group }}
+Type=forking
 PIDFile={{ hadoop_pid_dir }}/yarn/hadoop-yarn-nodemanager.pid
 ExecStart={{ hadoop_install_dir }}/bin/yarn --config {{ hadoop_nm_conf_dir }} --daemon start nodemanager
-ExecReload={{ hadoop_install_dir }}/bin/yarn --config {{ hadoop_nm_conf_dir }} --daemon restart nodemanager
 ExecStop={{ hadoop_install_dir }}/bin/yarn --config {{ hadoop_nm_conf_dir }} --daemon stop nodemanager
+SuccessExitStatus=143
 LimitNOFILE=64000
-Restart={{ yarn_nm_restart}}
+Restart={{ yarn_nm_restart }}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/yarn/common/templates/hadoop-yarn-resourcemanager.service.j2
+++ b/roles/yarn/common/templates/hadoop-yarn-resourcemanager.service.j2
@@ -4,12 +4,13 @@ Description=Yarn ResourceManager
 [Service]
 User={{ yarn_user }}
 Group={{ hadoop_group }}
+Type=forking
 PIDFile={{ hadoop_pid_dir }}/yarn/hadoop-yarn-resourcemanager.pid
 ExecStart={{ hadoop_install_dir }}/bin/yarn --config {{ hadoop_rm_conf_dir }} --daemon start resourcemanager
-ExecReload={{ hadoop_install_dir }}/bin/yarn --config {{ hadoop_rm_conf_dir }} --daemon restart resourcemanager
 ExecStop={{ hadoop_install_dir }}/bin/yarn --config {{ hadoop_rm_conf_dir }} --daemon stop resourcemanager
+SuccessExitStatus=143
 LimitNOFILE=64000
-Restart={{ yarn_rm_restart}}
+Restart={{ yarn_rm_restart }}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/yarn/common/templates/hadoop-yarn-timelineserver.service.j2
+++ b/roles/yarn/common/templates/hadoop-yarn-timelineserver.service.j2
@@ -4,12 +4,13 @@ Description=Yarn Timelineserver
 [Service]
 User={{ yarn_user }}
 Group={{ hadoop_group }}
+Type=forking
 PIDFile={{ hadoop_pid_dir }}/yarn/hadoop-yarn-timelineserver.pid
 ExecStart={{ hadoop_install_dir }}/bin/yarn --config {{ hadoop_ats_conf_dir }} --daemon start timelineserver
-ExecReload={{ hadoop_install_dir }}/bin/yarn --config {{ hadoop_ats_conf_dir }} --daemon restart timelineserver
 ExecStop={{ hadoop_install_dir }}/bin/yarn --config {{ hadoop_ats_conf_dir }} --daemon stop timelineserver
+SuccessExitStatus=143
 LimitNOFILE=64000
-Restart={{ yarn_ts_restart}}
+Restart={{ yarn_ts_restart }}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/zookeeper/common/templates/zookeeper.service.j2
+++ b/roles/zookeeper/common/templates/zookeeper.service.j2
@@ -9,7 +9,7 @@ User={{ zookeeper_user }}
 Group={{ hadoop_group }}
 ExecStart={{ zookeeper_install_dir }}/bin/zkServer.sh start
 ExecStop={{ zookeeper_install_dir }}/bin/zkServer.sh stop
-ExecReload={{ zookeeper_install_dir }}/bin/zkServer.sh restart
+SuccessExitStatus=SIGKILL
 Restart={{ zk_restart }}
 
 [Install]


### PR DESCRIPTION
Fix #135 and #134  review systemd :

- start : maintain the way We start each hadoop service/components with --daemon .
- stop:  add SuccessExitStatus=143 to have correct status(inactive) once process stopped.
- reload:  use restart instead of reload to make sure configs change will be token account.

ps: We could implement explicitely reload for some configs like "capacity-scheduler.xml" 