### PR TITLE
knox: add HBaseUI integration

### DIFF
--- a/tdp_vars_defaults/knox/knox.yml
+++ b/tdp_vars_defaults/knox/knox.yml
@@ -118,6 +118,10 @@ gateway_topology:
       YARNUI:
         hosts: "{{ groups['yarn_rm'] | map('tosit.tdp.access_fqdn', hostvars) | list }}"
         port: 8090
+      HBASEUI:
+        hosts: 
+          - "{{ groups['hbase_master'] | map('tosit.tdp.access_fqdn', hostvars) | first }}"
+        port: 16010
 
 # Service restart policies
 knox_restart: "no"


### PR DESCRIPTION
Fix #159 description: 
Now, you can navigate via `https://<gateway-address>/gateway/tdpldap/hbase/webui/master/master-status?host=<hbase-master-address>&port=16010 `  without any issue. This URL is very important, if you miss or change a part of it, the UI can have an unexpected behavior.