### PR TITLE
knox: add spark history server integration

### DIFF
--- a/roles/knox/common/templates/services/sparkhistoryui/2.3.0/rewrite.xml.j2
+++ b/roles/knox/common/templates/services/sparkhistoryui/2.3.0/rewrite.xml.j2
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<rules>
+  <rule dir="IN" name="SPARKHISTORYUI/sparkhistory/inbound/root" pattern="*://*:*/**/sparkhistory/">
+    <rewrite template="{$serviceUrl[SPARKHISTORYUI]}/"/>
+  </rule>
+  <rule dir="IN" name="SPARKHISTORYUI/sparkhistory/inbound/path" pattern="*://*:*/**/sparkhistory/{**}">
+    <rewrite template="{$serviceUrl[SPARKHISTORYUI]}/{**}"/>
+  </rule>
+  <rule dir="IN" name="SPARKHISTORYUI/sparkhistory/inbound/simpleQuery" pattern="*://*:*/**/sparkhistory/?{**}">
+    <rewrite template="{$serviceUrl[SPARKHISTORYUI]}/?{**}"/>
+  </rule>
+  <rule dir="IN" name="SPARKHISTORYUI/sparkhistory/inbound/query" pattern="*://*:*/**/sparkhistory/{**}?{**}">
+    <rewrite template="{$serviceUrl[SPARKHISTORYUI]}/{**}?{**}"/>
+  </rule>
+  <rule dir="IN" name="SPARKHISTORYUI/sparkhistory/inbound/history" pattern="*://*:*/**/sparkhistory/history/{**}/?{**}">
+    <rewrite template="{$serviceUrl[SPARKHISTORYUI]}/history/{**}/?{**}"/>
+  </rule>
+  <rule dir="IN" name="SPARKHISTORYUI/sparkhistory/inbound/apps" pattern="*://*:*/**/sparkhistory/?{page}?{showIncomplete}">
+    <rewrite template="{$serviceUrl[SPARKHISTORYUI]}/?{page}?{showIncomplete}"/>
+  </rule>
+
+  <rule dir="OUT" name="SPARKHISTORYUI/sparkhistory/outbound/history" pattern="/history/{**}">
+    <rewrite template="{$frontend[url]}/sparkhistory/history/{**}"/>
+  </rule>
+  <rule dir="OUT" name="SPARKHISTORYUI/sparkhistory/outbound/history/job" pattern="/history/{**}?{**}">
+    <rewrite template="{$frontend[url]}/sparkhistory/history/{**}?{**}"/>
+  </rule>
+
+  <rule dir="OUT" name="SPARKHISTORYUI/sparkhistory/outbound/apps" pattern="/?{page}?{showIncomplete}">
+    <rewrite template="{$frontend[url]}/sparkhistory/?{page}?{showIncomplete}"/>
+  </rule>
+
+  <rule dir="OUT" name="SPARKHISTORYUI/sparkhistory/outbound/headers/location">
+    <match pattern="*://*:*/history/{**}/?{**}"/>
+    <rewrite template="{$frontend[url]}/sparkhistory/history/{**}/?{**}"/>
+  </rule>
+  <rule flow="OR" dir="OUT" name="SPARKHISTORYUI/sparkhistory/outbound/headers/jobs/location">
+    <match pattern="*://*:*/history/{**}/jobs">
+      <rewrite template="{$frontend[url]}/sparkhistory/history/{**}/jobs"/>
+    </match>
+    <match pattern="*://*:*/history/{**}/jobs/">
+      <rewrite template="{$frontend[url]}/sparkhistory/history/{**}/jobs/"/>
+    </match>
+  </rule>
+  <rule dir="IN" name="SPARKHISTORYUI/sparkhistory/outbound/rqheaders/xfc">
+    <match pattern="{**}"/>
+    <rewrite template="/{**}/sparkhistory" />
+  </rule>
+
+  <filter name="SPARKHISTORYUI/sparkhistory/outbound/headers">
+    <content type="application/x-http-headers">
+      <apply path="Location" rule="SPARKHISTORYUI/sparkhistory/outbound/headers/location"/>
+    </content>
+  </filter>
+  <filter name="SPARKHISTORYUI/sparkhistory/outbound/headers/jobs">
+    <content type="application/x-http-headers">
+      <apply path="Location" rule="SPARKHISTORYUI/sparkhistory/outbound/headers/jobs/location"/>
+    </content>
+  </filter>
+  <filter name="SPARKHISTORYUI/sparkhistory/outbound/rqheaders">
+    <content type="application/x-http-headers">
+      <apply path="X-Forwarded-Context" rule="SPARKHISTORYUI/sparkhistory/outbound/rqheaders/xfc"/>
+    </content>
+  </filter>
+
+  <!-- re-write rule for location when SHS redirects to Knox SSO login page -->
+  <rule dir="OUT" name="SPARKHISTORYUI/sparkhistory/outbound/headers/location/sso">
+    <match pattern="{scheme}://{host}:{port}/{gateway}/{knoxsso}/{api}/{v}/websso?originalUrl={**}"/>
+    <rewrite template="{scheme}://{host}:{port}/{gateway}/{knoxsso}/{api}/{v}/websso?originalUrl={$postfix[url,/sparkhistory/]}"/>
+  </rule>
+  <filter name="SPARKHISTORYUI/sparkhistory/outbound/headers/sso/filter">
+    <content type="application/x-http-headers">
+      <apply path="Location" rule="SPARKHISTORYUI/sparkhistory/outbound/headers/location/sso"/>
+    </content>
+  </filter>
+
+  <!-- re-write rules for yarn container logs -->
+  <rule dir="OUT" name="SPARKHISTORYUI/sparkhistory/outbound/yarn/containerlogs" pattern="{scheme}://{host}:{port}/node/containerlogs/{**}">
+    <rewrite template="{$frontend[url]}/yarn/nodemanager/node/containerlogs/{**}?{scheme}?{host}?{port}"/>
+  </rule>
+
+  <rule dir="OUT" name="SPARKHISTORYUI/sparkhistory/outbound/yarn/containerlogs2" pattern="{scheme}://{host}:{port}/node/containerlogs/{**}?{**}">
+    <rewrite template="{$frontend[url]}/yarn/nodemanager/node/containerlogs/{**}?{**}?{scheme}?{host}?{port}"/>
+  </rule>
+</rules>

--- a/roles/knox/common/templates/services/sparkhistoryui/2.3.0/service.xml.j2
+++ b/roles/knox/common/templates/services/sparkhistoryui/2.3.0/service.xml.j2
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<service role="SPARKHISTORYUI" name="sparkhistory" version="2.3.0">
+    <routes>
+        <route path="/sparkhistory/">
+            <rewrite apply="SPARKHISTORYUI/sparkhistory/outbound/rqheaders" to="request.headers"/>
+            <rewrite apply="SPARKHISTORYUI/sparkhistory/outbound/headers/sso/filter" to="response.headers"/>
+        </route>
+        <route path="/sparkhistory/**">
+            <rewrite apply="SPARKHISTORYUI/sparkhistory/outbound/rqheaders" to="request.headers"/>
+            <rewrite apply="SPARKHISTORYUI/sparkhistory/outbound/headers/sso/filter" to="response.headers"/>
+        </route>
+        <route path="/sparkhistory/**?**"/>
+        <route path="/sparkhistory/history/**?**">
+            <rewrite apply="SPARKHISTORYUI/sparkhistory/outbound/headers" to="response.headers"/>
+            <rewrite apply="SPARKHISTORYUI/sparkhistory/outbound/rqheaders" to="request.headers"/>
+        </route>
+        <route path="/sparkhistory/history/**/?**">
+            <rewrite apply="SPARKHISTORYUI/sparkhistory/outbound/headers/jobs" to="response.headers"/>
+            <rewrite apply="SPARKHISTORYUI/sparkhistory/outbound/rqheaders" to="request.headers"/>
+        </route>
+        <route path="/sparkhistory/history/**/jobs/**?**">
+            <rewrite apply="SPARKHISTORYUI/sparkhistory/outbound/headers/jobs" to="response.headers"/>
+            <rewrite apply="SPARKHISTORYUI/sparkhistory/outbound/rqheaders" to="request.headers"/>
+        </route>
+    </routes>
+</service>

--- a/roles/knox/gateway/tasks/install.yml
+++ b/roles/knox/gateway/tasks/install.yml
@@ -8,6 +8,28 @@
   package:
     name: expect
 
+# Spark Historyserver service definition
+- name: Create Spark Historyserver service dir
+  file:
+    path: '{{ knox_install_dir }}/data/services/sparkhistoryui/2.3.0'
+    state: directory
+    group: '{{ knox_group }}'
+    owner: '{{ knox_user }}'
+
+- name: Template Spark Historyserver service.xml
+  template:
+    src: services/sparkhistoryui/2.3.0/service.xml.j2
+    dest: '{{ knox_install_dir }}/data/services/sparkhistoryui/2.3.0/service.xml'
+    group: '{{ knox_group }}'
+    owner: '{{ knox_user }}'
+
+- name: Template Spark Historyserver rewrite.xml
+  template:
+    src: services/sparkhistoryui/2.3.0/rewrite.xml.j2
+    dest: '{{ knox_install_dir }}/data/services/sparkhistoryui/2.3.0/rewrite.xml'
+    group: '{{ knox_group }}'
+    owner: '{{ knox_user }}'
+
 - name: Create configuration directory
   file:
     path: '{{ knox_conf_dir }}'

--- a/roles/spark/common/templates/spark-defaults.conf.j2
+++ b/roles/spark/common/templates/spark-defaults.conf.j2
@@ -1,3 +1,5 @@
 {% for name, value in spark_defaults.items() %}
+{% if value %}
 {{ name }} {{ value }}
+{% endif %}
 {% endfor %}

--- a/tdp_vars_defaults/knox/knox.yml
+++ b/tdp_vars_defaults/knox/knox.yml
@@ -107,7 +107,6 @@ gateway_topology:
       SPARKHISTORYUI:
         hosts: "{{ groups['spark_hs'] | map('tosit.tdp.access_fqdn', hostvars) | list }}"
         port: 18081
-        scheme: http://
       WEBHBASE:
         hosts: "{{ groups['hbase_rest'] | map('tosit.tdp.access_fqdn', hostvars) | list }}"
         port: 8080

--- a/tdp_vars_defaults/spark/spark.yml
+++ b/tdp_vars_defaults/spark/spark.yml
@@ -46,6 +46,8 @@ spark_defaults_client:
   spark.eventLog.dir: hdfs://mycluster/spark-logs
   spark.eventLog.enabled: "true"
   spark.hadoop.yarn.timeline-service.enabled: "false"
+  spark.yarn.historyServer.address: "{{ groups['spark_hs'][0] | tosit.tdp.access_fqdn(hostvars) }}:18081"
+  spark.master: yarn 
 
 # spark-default.conf - Spark History Server
 spark_defaults_hs:
@@ -53,6 +55,7 @@ spark_defaults_hs:
   spark.history.kerberos.keytab: /etc/security/keytabs/spark.service.keytab
   spark.history.kerberos.principal: "spark/{{ ansible_fqdn }}@{{ realm }}"
   spark.history.ui.acls.enable: "true"
+  spark.history.ui.admin.acls: "knox"
   spark.history.ui.port: 18080
   spark.ui.filters: org.apache.hadoop.security.authentication.server.AuthenticationFilter
   spark.org.apache.hadoop.security.authentication.server.AuthenticationFilter.params: type=kerberos,kerberos.principal={{ spark_ui_spnego_principal }},kerberos.keytab={{ spark_ui_spnego_keytab }}
@@ -61,6 +64,7 @@ spark_defaults_hs:
   spark.ssl.historyServer.keyStorePassword: "{{ spark_keystore_password }}"
   spark.ssl.historyServer.port: 18081
   spark.history.fs.logDirectory: hdfs://mycluster/spark-logs
+  spark.ui.proxyBase: "{% if 'knox' in groups and groups['knox'] %}/gateway/tdpldap/sparkhistory{% endif %}"
 
 # spark-env.sh
 spark_env:


### PR DESCRIPTION
fix #156 description:

- this PR doesn't require this closed [Knox PR](https://github.com/TOSIT-IO/knox/pull/1) 
- `spark.yarn.historyServer.address` in `spark-default.conf` enables direct link from `yarn resource manager `to `spark history server`
- impersonation is not actually possible in `spark history server`, so, `knox` user is configured as admin
- `spark.ui.proxyBase`  in `spark-default.conf` edits all `spark history server` URLs and makes the UI only available via `knox`. As a solution, you can deploy another `spark history server` for local usage 

Now, you can navigate via `https://<gateway-address>/gateway/tdpldap/yarn` and `https://<gateway-address>/gateway/tdpldap/sparkhistory` without any issue.