### PR TITLE
knox: yarn timeline rest integration

### DIFF
--- a/roles/knox/common/templates/services/yarn-timeline/3.0.0/rewrite.xml.j2
+++ b/roles/knox/common/templates/services/yarn-timeline/3.0.0/rewrite.xml.j2
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<rules>
+  <rule dir="IN" name="YARNTIMELINE/yarntimeline/ws/inbound" pattern="*://*:*/**/ws/v1/applicationhistory">
+    <rewrite template="{$serviceUrl[YARNTIMELINE]}/ws/v1/applicationhistory"/>
+  </rule>
+  <rule dir="IN" name="YARNTIMELINE/yarntimeline/inbound" pattern="*://*:*/**/ws/v1/applicationhistory/{**}?{**}">
+    <rewrite template="{$serviceUrl[YARNTIMELINE]}/ws/v1/applicationhistory/{**}?{**}"/>
+  </rule>
+</rules>

--- a/roles/knox/common/templates/services/yarn-timeline/3.0.0/service.xml.j2
+++ b/roles/knox/common/templates/services/yarn-timeline/3.0.0/service.xml.j2
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<service role="YARNTIMELINE" name="yarntimeline" version="3.0.0">
+  <routes>
+    <route path="/yarntimeline/ws/v1/applicationhistory">
+      <rewrite apply="YARNTIMELINE/yarntimeline/ws/inbound" to="request.url"/>
+    </route>
+
+    <route path="/yarntimeline/ws/v1/applicationhistory/{**}?{**}">
+      <rewrite apply="YARNTIMELINE/yarntimeline/inbound" to="request.url"/>
+    </route>
+  </routes>
+</service>

--- a/roles/knox/gateway/tasks/install.yml
+++ b/roles/knox/gateway/tasks/install.yml
@@ -30,6 +30,28 @@
     group: '{{ knox_group }}'
     owner: '{{ knox_user }}'
 
+# Yarn Timeline service definition
+- name: Create yarn timeline service dir
+  file:
+    path: '{{ knox_install_dir }}/data/services/yarntimeline/3.0.0'
+    state: directory
+    group: '{{ knox_group }}'
+    owner: '{{ knox_user }}'
+
+- name: Template Yarn Timeline service.xml
+  template:
+    src: services/yarn-timeline/3.0.0/service.xml.j2
+    dest: '{{ knox_install_dir }}/data/services/yarntimeline/3.0.0/service.xml'
+    group: '{{ knox_group }}'
+    owner: '{{ knox_user }}'
+
+- name: Template Yarn Timeline service.xml
+  template:
+    src: services/yarn-timeline/3.0.0/rewrite.xml.j2
+    dest: '{{ knox_install_dir }}/data/services/yarntimeline/3.0.0/rewrite.xml'
+    group: '{{ knox_group }}'
+    owner: '{{ knox_user }}'
+
 - name: Create configuration directory
   file:
     path: '{{ knox_conf_dir }}'

--- a/tdp_vars_defaults/knox/knox.yml
+++ b/tdp_vars_defaults/knox/knox.yml
@@ -121,6 +121,9 @@ gateway_topology:
         hosts: 
           - "{{ groups['hbase_master'] | map('tosit.tdp.access_fqdn', hostvars) | first }}"
         port: 16010
+      YARNTIMELINE:
+        hosts: "{{ groups['yarn_ats'] | map('tosit.tdp.access_fqdn', hostvars) | list }}"
+        port: 8190
 
 # Service restart policies
 knox_restart: "no"


### PR DESCRIPTION
Fix #160 

- this PR integrates Yarn Timeline Server (REST server) to Knox
- As this service is not natively supported by knox, team decided to close this PR that was created only to keep an history

Usage via the following url: `https://<gateway-adress>/gateway/tdpldap/yarntimeline/ws/v1/applicationhistory`