### PR TITLE
knox: add haprovider config for all supported services

### DIFF
--- a/tdp_vars_defaults/knox/knox.yml
+++ b/tdp_vars_defaults/knox/knox.yml
@@ -84,12 +84,18 @@ gateway_topology:
           WEBHBASE: "{{ topology_common_ha_configuration }}"
           WEBHDFS: "{{ topology_common_ha_configuration }}"
           YARNUI: "{{ topology_common_ha_configuration }}"
+          HBASEUI: "{{ topology_common_ha_configuration }}"
+          HDFSUI: "{{ topology_common_ha_configuration }}"
+          NAMENODE: "{{ topology_common_ha_configuration }}"
       identity-assertion:
         name: Default
     services:
+      NAMENODE:
+        hosts: "{{ groups['hdfs_nn'] | map('tosit.tdp.access_fqdn', hostvars) | list }}"
+        port: 8020
+        scheme: hdfs://
       HDFSUI:
-        hosts:
-          - "{{ groups['hdfs_nn'] | map('tosit.tdp.access_fqdn', hostvars) | first }}"
+        hosts: "{{ groups['hdfs_nn'] | map('tosit.tdp.access_fqdn', hostvars) | list }}"
         port: 9871
         version: 2.7.0
       JOBHISTORYUI:
@@ -118,8 +124,7 @@ gateway_topology:
         hosts: "{{ groups['yarn_rm'] | map('tosit.tdp.access_fqdn', hostvars) | list }}"
         port: 8090
       HBASEUI:
-        hosts: 
-          - "{{ groups['hbase_master'] | map('tosit.tdp.access_fqdn', hostvars) | first }}"
+        hosts: "{{ groups['hbase_master'] | map('tosit.tdp.access_fqdn', hostvars) | list }}"
         port: 16010
 
 # Service restart policies


### PR DESCRIPTION
Fix #158 

- all HA services are well configured and tested for better knox integration
- a new service: `NAMENODE` was added in order to resolve the address of the `active namenode` avoiding access to only `standby HDFS UI` via knox.