### PR TITLE
hive: move "hadoop credential create" from "install" to "config" for metastore

### DIFF
--- a/roles/hive/metastore/tasks/config.yml
+++ b/roles/hive/metastore/tasks/config.yml
@@ -9,6 +9,18 @@
   tags:
     - backup
 
+- name: Create hive credentials store
+  shell: |
+    {{ hadoop_home }}/bin/hadoop credential create javax.jdo.option.ConnectionPassword -value {{ hive_ms_db_password }} -provider {{ hive_ms_credentials_store_uri }}
+  args:
+    creates: '{{ hive_ms_credentials_store_path }}'
+
+- name: Ensure hive credentials store is 600 and owned by hive
+  file:
+    path: '{{ hive_ms_credentials_store_path }}'
+    mode: '600'
+    owner: '{{ hive_user }}'
+
 - name: Template hive-env.sh
   template:
     src: hive-env.sh.j2

--- a/roles/hive/metastore/tasks/install.yml
+++ b/roles/hive/metastore/tasks/install.yml
@@ -21,18 +21,6 @@
     group: '{{ hadoop_group }}'
     owner: '{{ hive_user }}'
 
-- name: Create hive credentials store
-  shell: |
-    {{ hadoop_home }}/bin/hadoop credential create javax.jdo.option.ConnectionPassword -value {{ hive_ms_db_password }} -provider {{ hive_ms_credentials_store_uri }}
-  args:
-    creates: '{{ hive_ms_credentials_store_path }}'
-
-- name: Ensure hive credentials store is 600 and owned by hive
-  file:
-    path: '{{ hive_ms_credentials_store_path }}'
-    mode: '600'
-    owner: '{{ hive_user }}'
-
 - name: Template HiveMetastore service file
   template:
     src: hive-metastore.service.j2


### PR DESCRIPTION
Fix #189 

`hadoop credential create` need `hadoop-env.sh` which is done via `hadoop_client_config`.

Same changes as #177 but for `metastore`.