### PR TITLE
hadoop: add symlink to hadoop client conf from hadoop install dir

### DIFF
--- a/roles/hadoop/client/tasks/install.yml
+++ b/roles/hadoop/client/tasks/install.yml
@@ -9,3 +9,14 @@
     state: directory
     group: root
     owner: root
+
+- name: Backup {{ hadoop_install_dir }}/etc/hadoop
+  command: mv {{ hadoop_install_dir }}/etc/hadoop {{ hadoop_install_dir }}/etc/hadoop.bk
+  args:
+    creates: "{{ hadoop_install_dir }}/etc/hadoop.bk"
+
+- name: Create symbolic link from etc/hadoop in {{ hadoop_install_dir }} to actual Hadoop client config dir
+  file:
+    src: "{{ hadoop_client_conf_dir }}"
+    dest: "{{ hadoop_install_dir }}/etc/hadoop"
+    state: link


### PR DESCRIPTION
Fix #191 

`hadoop` command read `/opt/tdp/hadoop/etc/hadoop/hadoop-env.sh` but the correct file is `/etc/hadoop/conf/hadoop-env.sh`. Add a symlink to fix it.