### PR TITLE
hbase: fix lib native load

### DIFF
--- a/roles/hbase/common/templates/hbase/hbase-env.sh.j2
+++ b/roles/hbase/common/templates/hbase/hbase-env.sh.j2
@@ -139,3 +139,6 @@ export HBASE_OPTS="$HBASE_OPTS -Djava.security.auth.login.config={{ hbase_client
 export HBASE_MASTER_OPTS="-Djava.security.auth.login.config={{ hbase_master_conf_dir }}/krb5JAASServer.conf"
 export HBASE_REGIONSERVER_OPTS="-Djava.security.auth.login.config={{ hbase_rs_conf_dir }}/krb5JAASServer.conf"
 export HBASE_REST_OPTS="-Djava.security.auth.login.config={{ hbase_rest_conf_dir }}/krb5JAASServer.conf"
+
+# Export hadoop lib native 
+export LD_LIBRARY_PATH="{{ hadoop_home }}/lib/native/:$LD_LIBRARY_PATH"

--- a/tdp_vars_defaults/hbase/hbase.yml
+++ b/tdp_vars_defaults/hbase/hbase.yml
@@ -17,6 +17,7 @@ hbase_install_dir: "{{ hbase_root_dir }}/hbase"
 
 # Hadoop configuration directory
 hadoop_conf_dir: /etc/hadoop/conf
+hadoop_home: "/opt/tdp/hadoop"
 
 # HBase configuration directories
 hbase_root_conf_dir: /etc/hbase


### PR DESCRIPTION
Fix #206

This PR aims to fix hadoop lib native load for HBase in order to resolve unsupported features requiring this config.
After this fix, this `WARN` should be removed from all hbase logs (master, rs, rest):
`WARN  [main] util.NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable`