### PR TITLE
exporter: add jmx-exporter for hdfs

### DIFF
--- a/playbooks/all.yml
+++ b/playbooks/all.yml
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
+- import_playbook: exporter.yml
 - import_playbook: zookeeper.yml
 - import_playbook: hadoop.yml
 - import_playbook: ranger.yml

--- a/playbooks/exporter.yml
+++ b/playbooks/exporter.yml
@@ -1,0 +1,5 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- import_playbook: exporter_jmx_install.yml

--- a/playbooks/exporter_jmx_install.yml
+++ b/playbooks/exporter_jmx_install.yml
@@ -1,0 +1,13 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: jmx-exporter install
+  hosts: hdfs_nn, hdfs_jn, hdfs_dn
+  tasks:
+    - tosit.tdp.resolve:
+        node_name: exporter_jmx
+    - import_role:
+        name: tosit.tdp.exporter.jmx
+        tasks_from: install
+    - meta: clear_facts

--- a/playbooks/hdfs.yml
+++ b/playbooks/hdfs.yml
@@ -17,6 +17,7 @@
 
 - import_playbook: hdfs_ranger_init.yml
 - import_playbook: hdfs_namenode_formatzk.yml
+- import_playbook: hdfs_jmx-exporter_config.yml
 - import_playbook: hdfs_journalnode_start.yml
 - import_playbook: hdfs_namenode_start.yml
 - import_playbook: hdfs_datanode_start.yml

--- a/playbooks/hdfs_jmx-exporter_config.yml
+++ b/playbooks/hdfs_jmx-exporter_config.yml
@@ -1,0 +1,31 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: jmx-exporter Namenode config
+  hosts: hdfs_nn
+  tasks:
+    - tosit.tdp.resolve:
+        node_name: hdfs_jmx-exporter
+    - import_role:
+        name: tosit.tdp.hdfs.namenode
+        tasks_from: jmx-exporter
+    - meta: clear_facts
+- name: jmx-exporter Journalnode config
+  hosts: hdfs_jn
+  tasks:
+    - tosit.tdp.resolve:
+        node_name: hdfs_jmx-exporter
+    - import_role:
+        name: tosit.tdp.hdfs.journalnode
+        tasks_from: jmx-exporter
+    - meta: clear_facts
+- name: jmx-exporter Datanode config
+  hosts: hdfs_dn
+  tasks:
+    - tosit.tdp.resolve:
+        node_name: hdfs_jmx-exporter
+    - import_role:
+        name: tosit.tdp.hdfs.datanode
+        tasks_from: jmx-exporter
+    - meta: clear_facts

--- a/roles/exporter/jmx/tasks/install.yml
+++ b/roles/exporter/jmx/tasks/install.yml
@@ -1,0 +1,20 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Ensures "{{ jmx_exporter_root_dir }}" exists
+  file:
+    path: "{{ jmx_exporter_root_dir }}"
+    state: directory
+
+- name: Upload jmx-exporter jar
+  copy:
+    src: "files/{{ jmx_exporter_dist_file }}"
+    dest: "{{ jmx_exporter_root_dir }}"
+  diff: no
+
+- name: Create symbolic link to jmx exporter jar
+  file:
+    src: "{{ jmx_exporter_root_dir }}/{{ jmx_exporter_dist_file }}"
+    dest: "{{ jmx_exporter_install_file }}"
+    state: link

--- a/roles/hadoop/client/tasks/config.yml
+++ b/roles/hadoop/client/tasks/config.yml
@@ -19,6 +19,7 @@
   vars:
     hadoop_log_dir: "{{ hadoop_env_client_log_dir }}"
     hadoop_pid_dir: "{{ hadoop_client_pid_dir }}"
+    hadoop_conf_dir: "{{ hadoop_client_conf_dir }}"
 
 - name: Template log4j.properties
   template:

--- a/roles/hadoop/common/templates/hadoop-env.sh.j2
+++ b/roles/hadoop/common/templates/hadoop-env.sh.j2
@@ -292,6 +292,8 @@ export HADOOP_PID_DIR={{ hadoop_pid_dir }}
 #
 # a) Set JMX options
 # export HDFS_NAMENODE_OPTS="-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=1026"
+export JMX_OPTS="{{ jmx_common_opts }} -Dcom.sun.management.jmxremote.password.file={{ hadoop_conf_dir }}/jmxremote.password"
+export HDFS_NAMENODE_OPTS="${JMX_OPTS} {{ jmx_exporter_nn_opts }} ${HDFS_NAMENODE_OPTS}"
 #
 # b) Set garbage collection logs
 # export HDFS_NAMENODE_OPTS="${HADOOP_GC_SETTINGS} -Xloggc:${HADOOP_LOG_DIR}/gc-rm.log-$(date +'%Y%m%d%H%M')"
@@ -321,6 +323,7 @@ export HADOOP_PID_DIR={{ hadoop_pid_dir }}
 #
 # This is the default:
 # export HDFS_DATANODE_OPTS="-Dhadoop.security.logger=ERROR,RFAS"
+export HDFS_DATANODE_OPTS="${JMX_OPTS} {{ jmx_exporter_dn_opts }} ${HDFS_DATANODE_OPTS}"
 
 # On secure datanodes, user to run the datanode as after dropping privileges.
 # This **MUST** be uncommented to enable secure HDFS if using privileged ports
@@ -367,6 +370,7 @@ export HADOOP_PID_DIR={{ hadoop_pid_dir }}
 # and therefore may override any similar flags set in HADOOP_OPTS
 #
 # export HDFS_ZKFC_OPTS=""
+export HDFS_ZKFC_OPTS="${JMX_OPTS} {{ jmx_exporter_zkfc_opts }} {{ jaas_nn_opts }} ${HDFS_ZKFC_OPTS}"
 
 ###
 # QuorumJournalNode specific parameters
@@ -376,7 +380,7 @@ export HADOOP_PID_DIR={{ hadoop_pid_dir }}
 # and therefore may override any similar flags set in HADOOP_OPTS
 #
 # export HDFS_JOURNALNODE_OPTS=""
-
+export HDFS_JOURNALNODE_OPTS="${JMX_OPTS} {{ jmx_exporter_jn_opts }}  ${HDFS_JOURNALNODE_OPTS}"
 ###
 # HDFS Balancer specific parameters
 ###
@@ -420,5 +424,3 @@ export HADOOP_PID_DIR={{ hadoop_pid_dir }}
 #
 # For example, to limit who can execute the namenode command,
 # export HDFS_NAMENODE_USER=hdfs
-
-export HDFS_ZKFC_OPTS="{{ hdfs_zkfc_opts }} ${HDFS_ZKFC_OPTS}"

--- a/roles/hdfs/common/templates/jmxremote.password.j2
+++ b/roles/hdfs/common/templates/jmxremote.password.j2
@@ -1,0 +1,1 @@
+{{ jmxremote_username }} {{ jmxremote_password }}

--- a/roles/hdfs/datanode/tasks/config.yml
+++ b/roles/hdfs/datanode/tasks/config.yml
@@ -19,6 +19,7 @@
   vars:
     hadoop_log_dir: "{{ hadoop_hdfs_log_dir }}"
     hadoop_pid_dir: "{{ hadoop_hdfs_pid_dir }}"
+    hadoop_conf_dir: "{{ hadoop_dn_conf_dir }}"
 
 - name: Template log4j.properties
   template:
@@ -36,3 +37,8 @@
   template:
     src: hdfs-site.xml.j2
     dest: '{{ hadoop_dn_conf_dir }}/hdfs-site.xml'
+
+- name: Render jmxremote.password
+  template:
+    src: jmxremote.password.j2
+    dest: '{{ hadoop_dn_conf_dir }}/jmxremote.password'

--- a/roles/hdfs/datanode/tasks/jmx-exporter.yml
+++ b/roles/hdfs/datanode/tasks/jmx-exporter.yml
@@ -1,0 +1,13 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Ensure configuration directory
+  file:
+    path: '{{ jmx_exporter_conf_dir }}'
+    state: directory
+
+- name: Render jmx-exporter config file jmx-exporter.yml
+  copy:
+    content: "{{ jmx_exporter | to_nice_yaml }}"
+    dest: "{{ jmx_exporter_conf_dir }}/dn.yml"

--- a/roles/hdfs/journalnode/tasks/config.yml
+++ b/roles/hdfs/journalnode/tasks/config.yml
@@ -19,6 +19,7 @@
   vars:
     hadoop_log_dir: "{{ hadoop_hdfs_log_dir }}"
     hadoop_pid_dir: "{{ hadoop_hdfs_pid_dir }}"
+    hadoop_conf_dir: "{{ hadoop_jn_conf_dir }}"
 
 - name: Template log4j.properties
   template:
@@ -36,3 +37,8 @@
   template:
     src: hdfs-site.xml.j2
     dest: '{{ hadoop_jn_conf_dir }}/hdfs-site.xml'
+
+- name: Render jmxremote.password
+  template:
+    src: jmxremote.password.j2
+    dest: '{{ hadoop_jn_conf_dir }}/jmxremote.password'

--- a/roles/hdfs/journalnode/tasks/jmx-exporter.yml
+++ b/roles/hdfs/journalnode/tasks/jmx-exporter.yml
@@ -1,0 +1,13 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Ensure configuration directory
+  file:
+    path: '{{ jmx_exporter_conf_dir }}'
+    state: directory
+
+- name: Render jmx-exporter config file jmx-exporter.yml
+  copy:
+    content: "{{ jmx_exporter | to_nice_yaml }}"
+    dest: "{{ jmx_exporter_conf_dir }}/jn.yml"

--- a/roles/hdfs/namenode/tasks/config.yml
+++ b/roles/hdfs/namenode/tasks/config.yml
@@ -19,7 +19,7 @@
   vars:
     hadoop_log_dir: "{{ hadoop_hdfs_log_dir }}"
     hadoop_pid_dir: "{{ hadoop_hdfs_pid_dir }}"
-    hdfs_zkfc_opts: "{{ hdfs_zkfc_nn_opts }}"
+    hadoop_conf_dir: "{{ hadoop_nn_conf_dir }}"
 
 - name: Template log4j.properties
   template:
@@ -42,3 +42,8 @@
   template:
     src: hdfs-site.xml.j2
     dest: '{{ hadoop_nn_conf_dir }}/hdfs-site.xml'
+
+- name: Render jmxremote.password
+  template:
+    src: jmxremote.password.j2
+    dest: '{{ hadoop_nn_conf_dir }}/jmxremote.password'

--- a/roles/hdfs/namenode/tasks/jmx-exporter.yml
+++ b/roles/hdfs/namenode/tasks/jmx-exporter.yml
@@ -1,0 +1,18 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Ensure configuration directory
+  file:
+    path: '{{ jmx_exporter_conf_dir }}'
+    state: directory
+
+- name: Render jmx-exporter config file jmx-exporter.yml
+  copy:
+    content: "{{ jmx_exporter | to_nice_yaml }}"
+    dest: "{{ jmx_exporter_conf_dir }}/nn.yml"
+
+- name: Render jmx-exporter config file jmx-exporter.yml
+  copy:
+    content: "{{ jmx_exporter | to_nice_yaml }}"
+    dest: "{{ jmx_exporter_conf_dir }}/zkfc.yml"

--- a/roles/yarn/apptimelineserver/tasks/config.yml
+++ b/roles/yarn/apptimelineserver/tasks/config.yml
@@ -19,6 +19,7 @@
   vars:
     hadoop_log_dir: "{{ hadoop_yarn_log_dir }}"
     hadoop_pid_dir: "{{ hadoop_yarn_pid_dir }}"
+    hadoop_conf_dir: "{{ hadoop_ats_conf_dir }}"
 
 - name: Template log4j.properties
   template:

--- a/roles/yarn/jobhistoryserver/tasks/config.yml
+++ b/roles/yarn/jobhistoryserver/tasks/config.yml
@@ -19,6 +19,7 @@
   vars:
     hadoop_log_dir: "{{ hadoop_mapred_log_dir }}"
     hadoop_pid_dir: "{{ hadoop_mapred_pid_dir }}"
+    hadoop_conf_dir: "{{ hadoop_jhs_conf_dir }}"
 
 - name: Template log4j.properties
   template:

--- a/roles/yarn/nodemanager/tasks/config.yml
+++ b/roles/yarn/nodemanager/tasks/config.yml
@@ -19,6 +19,7 @@
   vars:
     hadoop_log_dir: "{{ hadoop_yarn_log_dir }}"
     hadoop_pid_dir: "{{ hadoop_yarn_pid_dir }}"
+    hadoop_conf_dir: "{{ hadoop_nm_conf_dir }}"
 
 - name: Template log4j.properties
   template:

--- a/roles/yarn/resourcemanager/tasks/config.yml
+++ b/roles/yarn/resourcemanager/tasks/config.yml
@@ -19,6 +19,7 @@
   vars:
     hadoop_log_dir: "{{ hadoop_yarn_log_dir }}"
     hadoop_pid_dir: "{{ hadoop_yarn_pid_dir }}"
+    hadoop_conf_dir: "{{ hadoop_rm_conf_dir }}"
 
 - name: Template log4j.properties
   template:

--- a/tdp_vars_defaults/exporter/exporter.yml
+++ b/tdp_vars_defaults/exporter/exporter.yml
@@ -1,0 +1,17 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+##############
+#jmx-exporter#
+##############
+# jmx exporter version
+jmx_exporter_release: jmx_prometheus_javaagent-0.16.1
+jmx_exporter_dist_file: "{{ jmx_exporter_release }}.jar"
+
+# jmx exporter installation directory
+jmx_exporter_root_dir: /opt/tdp/jmx-exporter
+jmx_exporter_install_file: "{{ jmx_exporter_root_dir }}/jmx-exporter.jar"
+
+# jmx exporter configuration directory
+jmx_exporter_conf_dir: /etc/jmx-exporter

--- a/tdp_vars_defaults/hadoop/hadoop.yml
+++ b/tdp_vars_defaults/hadoop/hadoop.yml
@@ -30,9 +30,23 @@ hadoop_jhs_conf_dir: "{{ hadoop_root_conf_dir }}/conf.jhs"
 hadoop_pid_dir: /run/hadoop
 hadoop_client_pid_dir: /run/hadoop/$USER
 
-# ZKFC options
-hdfs_zkfc_opts: ""
-hdfs_zkfc_nn_opts: "-Djava.security.auth.login.config={{ hadoop_nn_conf_dir }}/krb5JAASnn.conf"
+# jmx exporter installation directory
+jmx_exporter_root_dir: /opt/tdp/jmx-exporter
+jmx_exporter_install_file: "{{ jmx_exporter_root_dir }}/jmx-exporter.jar"
+
+# jmx exporter configuration directory
+jmx_exporter_conf_dir: /etc/jmx-exporter
+
+# HDFS JVM options
+jmx_common_opts: "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.authenticate=true -Dcom.sun.management.jmxremote.ssl=true"
+jaas_nn_opts: "-Djava.security.auth.login.config={{ hadoop_nn_conf_dir }}/krb5JAASnn.conf"
+
+# jmx-exporter
+jmx_exporter_nn_opts: "{% if 'exporter_jmx' in groups and groups['exporter_jmx'] %}-javaagent:{{ jmx_exporter_install_file }}=18101:{{ jmx_exporter_conf_dir }}/nn.yml{% else %}{% endif %}"
+jmx_exporter_zkfc_opts: "{% if 'exporter_jmx' in groups and groups['exporter_jmx'] %}-javaagent:{{ jmx_exporter_install_file }}=18102:{{ jmx_exporter_conf_dir }}/zkfc.yml{% else %}{% endif %}"
+jmx_exporter_jn_opts: "{% if 'exporter_jmx' in groups and groups['exporter_jmx'] %}-javaagent:{{ jmx_exporter_install_file }}=18103:{{ jmx_exporter_conf_dir }}/jn.yml{% else %}{% endif %}"
+jmx_exporter_dn_opts: "{% if 'exporter_jmx' in groups and groups['exporter_jmx'] %}-javaagent:{{ jmx_exporter_install_file }}=18104:{{ jmx_exporter_conf_dir }}/dn.yml{% else %}{% endif %}"
+
 
 # Hadoop logging directory
 hadoop_log_dir: /var/log/hadoop
@@ -135,3 +149,15 @@ mapred_site:
   mapreduce.jobhistory.http.policy: HTTPS_ONLY
   mapreduce.jobhistory.webapp.spnego-principal: HTTP/_HOST@{{ realm }} 
   mapreduce.jobhistory.webapp.spnego-keytab-file: /etc/security/keytabs/spnego.service.keytab
+
+jmxremote_username: jmxuser
+jmxremote_password: Tdpjmx123,
+#jmx-exporter.yml
+jmx_exporter:
+  startDelaySeconds: 0
+  ssl: true
+  username: "{{ jmxremote_username }}"
+  password: "{{ jmxremote_password }}"
+  lowercaseOutputName: false
+  lowercaseOutputLabelNames: false
+


### PR DESCRIPTION
this PR is to add jmx-exporter for **hdfs** regarding #195,  other PRs will come per service.

- add a exporter role at service level and jmx-exporter as a first component, other exporter is comming... 
- re-factoring hadoop-env.sh
- enable jmx for hdfs with authc and tls 
- add jmx-exporter for hdfs