### PR TITLE
spark: configure spark commands for better usage

### DIFF
--- a/roles/spark/client/tasks/config.yml
+++ b/roles/spark/client/tasks/config.yml
@@ -16,10 +16,12 @@
   template:
     src: spark-env.sh.j2
     dest: '{{ spark_client_conf_dir }}/spark-env.sh'
+  vars: 
+    spark_env: "{{ spark_env_common }}"
 
 - name: Template spark-defaults.conf
   template:
     src: spark-defaults.conf.j2
     dest: '{{ spark_client_conf_dir }}/spark-defaults.conf'
   vars: 
-    spark_defaults: "{{ spark_defaults_common | combine(spark_defaults_client )}}"
+    spark_defaults: "{{ spark_defaults_common | combine(spark_defaults_client) }}"

--- a/roles/spark/client/tasks/install.yml
+++ b/roles/spark/client/tasks/install.yml
@@ -30,3 +30,9 @@
     src: spark-sql-command.j2
     dest: /usr/bin/spark-sql
     mode: 0755
+
+- name: Render /usr/bin/pyspark command
+  template:
+    src: pyspark-command.j2
+    dest: /usr/bin/pyspark
+    mode: 0755

--- a/roles/spark/client/tasks/install.yml
+++ b/roles/spark/client/tasks/install.yml
@@ -12,3 +12,21 @@
     state: directory
     group: '{{ hadoop_group }}'
     owner: '{{ spark_user }}'
+
+- name: Render /usr/bin/spark-submit command
+  template:
+    src: spark-submit-command.j2
+    dest: /usr/bin/spark-submit
+    mode: 0755
+
+- name: Render /usr/bin/spark-shell command
+  template:
+    src: spark-shell-command.j2
+    dest: /usr/bin/spark-shell
+    mode: 0755
+
+- name: Render /usr/bin/spark-sql command
+  template:
+    src: spark-sql-command.j2
+    dest: /usr/bin/spark-sql
+    mode: 0755

--- a/roles/spark/common/templates/pyspark-command.j2
+++ b/roles/spark/common/templates/pyspark-command.j2
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+export SPARK_CONF_DIR={{ spark_client_conf_dir }}
+
+{{ spark_install_dir }}/bin/pyspark "$@"

--- a/roles/spark/common/templates/spark-shell-command.j2
+++ b/roles/spark/common/templates/spark-shell-command.j2
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+export SPARK_CONF_DIR={{ spark_client_conf_dir }}
+
+{{ spark_install_dir }}/bin/spark-shell "$@"

--- a/roles/spark/common/templates/spark-sql-command.j2
+++ b/roles/spark/common/templates/spark-sql-command.j2
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+export SPARK_CONF_DIR={{ spark_client_conf_dir }}
+
+{{ spark_install_dir }}/bin/spark-sql "$@"

--- a/roles/spark/common/templates/spark-submit-command.j2
+++ b/roles/spark/common/templates/spark-submit-command.j2
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+export SPARK_CONF_DIR={{ spark_client_conf_dir }}
+
+{{ spark_install_dir }}/bin/spark-submit "$@"

--- a/roles/spark/historyserver/tasks/config.yml
+++ b/roles/spark/historyserver/tasks/config.yml
@@ -16,10 +16,12 @@
   template:
     src: spark-env.sh.j2
     dest: '{{ spark_hs_conf_dir }}/spark-env.sh'
+  vars: 
+    spark_env: "{{ spark_env_common | combine(spark_env_hs) }}"
 
 - name: Template spark-defaults.conf
   template:
     src: spark-defaults.conf.j2
     dest: '{{ spark_hs_conf_dir }}/spark-defaults.conf'
   vars: 
-    spark_defaults: "{{ spark_defaults_common | combine(spark_defaults_hs )}}"
+    spark_defaults: "{{ spark_defaults_common | combine(spark_defaults_hs) }}"

--- a/tdp_vars_defaults/spark/spark.yml
+++ b/tdp_vars_defaults/spark/spark.yml
@@ -71,12 +71,18 @@ spark_defaults_hs:
   spark.history.provider: org.apache.spark.deploy.history.FsHistoryProvider
   spark.ui.proxyBase: "{% if 'knox' in groups and groups['knox'] %}/gateway/tdpldap/sparkhistory{% endif %}"
 
-# spark-env.sh
-spark_env:
+# spark-env.sh - common
+spark_env_common:
   HADOOP_CONF_DIR: "{{ hadoop_conf_dir }}"
   HADOOP_HOME: "{{ hadoop_home }}"
-  SPARK_LOG_DIR: "{{ spark_log_dir }}"
   LD_LIBRARY_PATH: "'{{ hadoop_home }}/lib/native/:$LD_LIBRARY_PATH'"
+
+# spark-env.sh - Spark History Server
+spark_env_hs:
+  SPARK_LOG_DIR: "{{ spark_log_dir }}"
+
+# spark-env.sh - Spark Client
+spark_env_client:
 
 # Service restart policies
 spark_hs_restart: "no"


### PR DESCRIPTION
Fix #225 description:

- split `spark-env.sh` vars for `spark_client` and `spark_hs` 
- configure `spark-submit`, `spark-shell` and `spark-sql` commands for direct usage



