### PR TITLE
hive: fix hive command usage from edge

### DIFF
--- a/roles/hive/client/tasks/config.yml
+++ b/roles/hive/client/tasks/config.yml
@@ -12,6 +12,18 @@
   tags:
     - backup
 
+- name: Create hive credentials store
+  shell: |
+    {{ hadoop_home }}/bin/hadoop credential create javax.jdo.option.ConnectionPassword -value {{ hive_ms_db_password }} -provider {{ hive_client_credentials_store_uri }}
+  args:
+    creates: '{{ hive_client_credentials_store_path }}'
+
+- name: Ensure hive credentials store is 600 and owned by hive
+  file:
+    path: '{{ hive_client_credentials_store_path }}'
+    mode: '600'
+    owner: '{{ hive_user }}'
+
 - name: Template hive-env.sh
   template:
     src: hive-env.sh.j2

--- a/roles/hive/hiveserver2/tasks/config.yml
+++ b/roles/hive/hiveserver2/tasks/config.yml
@@ -14,13 +14,13 @@
 
 - name: Create hive credentials store
   shell: |
-    {{ hadoop_home }}/bin/hadoop credential create javax.jdo.option.ConnectionPassword -value {{ hive_ms_db_password }} -provider {{ hive_ms_credentials_store_uri }}
+    {{ hadoop_home }}/bin/hadoop credential create javax.jdo.option.ConnectionPassword -value {{ hive_ms_db_password }} -provider {{ hive_s2_credentials_store_uri }}
   args:
-    creates: '{{ hive_ms_credentials_store_path }}'
+    creates: '{{ hive_s2_credentials_store_path }}'
 
 - name: Ensure hive credentials store is 600 and owned by hive
   file:
-    path: '{{ hive_ms_credentials_store_path }}'
+    path: '{{ hive_s2_credentials_store_path }}'
     mode: '600'
     owner: '{{ hive_user }}'
 

--- a/tdp_vars_defaults/hive/hive.yml
+++ b/tdp_vars_defaults/hive/hive.yml
@@ -40,8 +40,6 @@ hive_ms_db_url: jdbc:mysql://tdp-db-1.lxd:3306
 hive_ms_db_name: hive
 hive_ms_db_user: hive
 hive_ms_db_password: hive123
-hive_ms_credentials_store_path: "{{ hive_s2_conf_dir }}/hive.jceks"
-hive_ms_credentials_store_uri: localjceks://file{{ hive_ms_credentials_store_path }}
 db_type: mysql
 
 # SSL Keystore and Truststore
@@ -56,7 +54,6 @@ hive_site:
   datanucleus.schema.auto: "false"
   javax.jdo.option.ConnectionDriverName: com.mysql.jdbc.Driver
   javax.jdo.option.ConnectionUserName: "{{ hive_ms_db_user }}"
-  hadoop.security.credential.provider.path: "{{ hive_ms_credentials_store_uri }}"
   metastore.hmshandler.retry.interval: 2
   metastore.stats.autogather: "true"
   metastore.uris: thrift://{{ groups['hive_ms'][0] | tosit.tdp.access_fqdn(hostvars) }}:9083

--- a/tdp_vars_defaults/hive/hive_client.yml
+++ b/tdp_vars_defaults/hive/hive_client.yml
@@ -1,0 +1,10 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+# Hive Client properties
+hive_client_credentials_store_path: "{{ hive_client_conf_dir }}/hive.jceks"
+hive_client_credentials_store_uri: localjceks://file{{ hive_client_credentials_store_path }}
+
+hive_site:
+  hadoop.security.credential.provider.path: "{{ hive_client_credentials_store_uri }}"

--- a/tdp_vars_defaults/hive/hive_hiveserver2.yml
+++ b/tdp_vars_defaults/hive/hive_hiveserver2.yml
@@ -1,0 +1,10 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+# Hive Hiveserver2 properties
+hive_s2_credentials_store_path: "{{ hive_s2_conf_dir }}/hive.jceks"
+hive_s2_credentials_store_uri: localjceks://file{{ hive_s2_credentials_store_path }}
+
+hive_site:
+  hadoop.security.credential.provider.path: "{{ hive_s2_credentials_store_uri }}"

--- a/tdp_vars_defaults/hive/hive_metastore.yml
+++ b/tdp_vars_defaults/hive/hive_metastore.yml
@@ -2,5 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-# Hive Metastore database properties
+# Hive Metastore properties
 hive_ms_credentials_store_path: "{{ hive_ms_conf_dir }}/hive.jceks"
+hive_ms_credentials_store_uri: localjceks://file{{ hive_ms_credentials_store_path }}
+
+hive_site:
+  hadoop.security.credential.provider.path: "{{ hive_ms_credentials_store_uri }}"


### PR DESCRIPTION
Fix #228 description: 

- hive command can be used only by `hive` user as `hive.jceks` file was created with the following permissions : `-rw-------. 1 hive root 522 Apr 15 16:46 /etc/hive/conf/hive.jceks`
- a specific default_vars file was defined by component