### PR TITLE
knox: move tdp custom service def from install to config

### DIFF
--- a/roles/knox/gateway/tasks/config.yml
+++ b/roles/knox/gateway/tasks/config.yml
@@ -28,6 +28,35 @@
     owner: '{{ knox_user }}'
     remote_src: yes
 
+# Spark Historyserver service definition
+- name: Create Spark Historyserver service dir
+  file:
+    path: '{{ knox_data_dir }}/data/services/sparkhistoryui/2.3.0'
+    state: directory
+    group: '{{ knox_group }}'
+    owner: '{{ knox_user }}'
+
+- name: Template Spark Historyserver service.xml
+  template:
+    src: services/sparkhistoryui/2.3.0/service.xml.j2
+    dest: '{{ knox_data_dir }}/data/services/sparkhistoryui/2.3.0/service.xml'
+    group: '{{ knox_group }}'
+    owner: '{{ knox_user }}'
+
+- name: Template Spark Historyserver rewrite.xml
+  template:
+    src: services/sparkhistoryui/2.3.0/rewrite.xml.j2
+    dest: '{{ knox_data_dir }}/data/services/sparkhistoryui/2.3.0/rewrite.xml'
+    group: '{{ knox_group }}'
+    owner: '{{ knox_user }}'
+
+- name: Template Yarn UI rewrite.xml
+  template:
+    src: services/yarnui/2.7.0/rewrite.xml.j2
+    dest: '{{ knox_data_dir }}/data/services/yarnui/2.7.0/rewrite.xml'
+    group: '{{ knox_group }}'
+    owner: '{{ knox_user }}'
+
 - name: Template Knox gateway-site.xml
   template:
     src: gateway-site.xml.j2

--- a/roles/knox/gateway/tasks/install.yml
+++ b/roles/knox/gateway/tasks/install.yml
@@ -11,35 +11,6 @@
   package:
     name: expect
 
-# Spark Historyserver service definition
-- name: Create Spark Historyserver service dir
-  file:
-    path: '{{ knox_install_dir }}/data/services/sparkhistoryui/2.3.0'
-    state: directory
-    group: '{{ knox_group }}'
-    owner: '{{ knox_user }}'
-
-- name: Template Spark Historyserver service.xml
-  template:
-    src: services/sparkhistoryui/2.3.0/service.xml.j2
-    dest: '{{ knox_install_dir }}/data/services/sparkhistoryui/2.3.0/service.xml'
-    group: '{{ knox_group }}'
-    owner: '{{ knox_user }}'
-
-- name: Template Spark Historyserver rewrite.xml
-  template:
-    src: services/sparkhistoryui/2.3.0/rewrite.xml.j2
-    dest: '{{ knox_install_dir }}/data/services/sparkhistoryui/2.3.0/rewrite.xml'
-    group: '{{ knox_group }}'
-    owner: '{{ knox_user }}'
-
-- name: Template Yarn UI rewrite.xml
-  template:
-    src: services/yarnui/2.7.0/rewrite.xml.j2
-    dest: '{{ knox_install_dir }}/data/services/yarnui/2.7.0/rewrite.xml'
-    group: '{{ knox_group }}'
-    owner: '{{ knox_user }}'
-
 - name: Create configuration directory
   file:
     path: '{{ knox_conf_dir }}'


### PR DESCRIPTION
<!--  Thank you for sending a pull request! Please make sure:

1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes:
<!--
Example: "Fixes #(issue number)" or "Fixes (link of issue)".
-->
Fixes #268 
Depends on #265 for merge to master
Move tdp custom files from `knox_install_dir` to `knox_data_dir` in order to keep original files.

#### Additional comments:
<!--
Example: `"I was not sure if it is the right way to do but..."
-->

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to [TOSIT](https://www.tosit.io/),
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.

