### PR TITLE
fix(spark): create spark user on namenodes

### DIFF
--- a/playbooks/spark3_hdfs_init.yml
+++ b/playbooks/spark3_hdfs_init.yml
@@ -12,3 +12,14 @@
         name: tosit.tdp.spark.common
         tasks_from: hdfs_init
     - meta: clear_facts
+
+- name: Post install steps for Spark - NameNode
+  hosts: hdfs_nn
+  strategy: linear
+  tasks:
+    - tosit.tdp.resolve:
+        node_name: spark3_hdfs
+    - import_role:
+        name: tosit.tdp.spark.common
+        tasks_from: hdfs_user
+    - meta: clear_facts

--- a/playbooks/spark_hdfs_init.yml
+++ b/playbooks/spark_hdfs_init.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-- name: Post install steps for Spark
+- name: Post install steps for Spark - Edge
   hosts: edge
   strategy: linear
   tasks:
@@ -11,4 +11,15 @@
     - import_role:
         name: tosit.tdp.spark.common
         tasks_from: hdfs_init
+    - meta: clear_facts
+
+- name: Post install steps for Spark - NameNode
+  hosts: hdfs_nn
+  strategy: linear
+  tasks:
+    - tosit.tdp.resolve:
+        node_name: spark_hdfs
+    - import_role:
+        name: tosit.tdp.spark.common
+        tasks_from: hdfs_user
     - meta: clear_facts

--- a/roles/spark/common/tasks/hdfs_user.yml
+++ b/roles/spark/common/tasks/hdfs_user.yml
@@ -1,0 +1,10 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+# Create spark user on HDFS NameNodes
+- include_role:
+    name: tosit.tdp.utils.user
+  vars:
+    user: "{{ spark_user }}"
+    group: "{{ hadoop_group }}"

--- a/roles/spark/common/tasks/install.yml
+++ b/roles/spark/common/tasks/install.yml
@@ -31,14 +31,14 @@
 
 - name: Create directory for pid
   file:
-    path: '{{ spark_pid_dir }}'
+    path: "{{ spark_pid_dir }}"
     state: directory
-    group: '{{ hadoop_group }}'
-    owner: '{{ spark_user }}'
+    group: "{{ hadoop_group }}"
+    owner: "{{ spark_user }}"
 
 - name: Create log directory
   file:
-    path: '{{ spark_log_dir }}'
+    path: "{{ spark_log_dir }}"
     state: directory
-    group: '{{ hadoop_group }}'
-    owner: '{{ spark_user }}'
+    group: "{{ hadoop_group }}"
+    owner: "{{ spark_user }}"


### PR DESCRIPTION
<!--  Thank you for sending a pull request! Please make sure:

1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes:
<!--
Example: "Fixes #(issue number)" or "Fixes (link of issue)".
-->
Fixes #257 

#### Additional comments:
<!--
Example: `"I was not sure if it is the right way to do but..."
-->

This PR ensure the creation of the `spark_user` on HDFS NameNodes so that it can access `(spark|spark3)-logs` dir.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to [TOSIT](https://www.tosit.io/),
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.

