### PR TITLE
spark: integrate hive for sql usage 

### DIFF
--- a/roles/spark/client/tasks/config.yml
+++ b/roles/spark/client/tasks/config.yml
@@ -25,3 +25,8 @@
     dest: "{{ spark_client_conf_dir }}/spark-defaults.conf"
   vars:
     spark_defaults: "{{ spark_defaults_common | combine(spark_defaults_client) }}"
+
+- name: Template hive-site.xml for spark
+  template:
+    src: hive-site.xml.j2
+    dest: "{{ spark_client_conf_dir }}/hive-site.xml"

--- a/roles/spark/common/templates/hive-site.xml.j2
+++ b/roles/spark/common/templates/hive-site.xml.j2
@@ -1,0 +1,8 @@
+<configuration>
+  {% for name, value in hive_site_spark.items() %}
+  <property>
+    <name>{{ name }}</name>
+    <value>{{ value }}</value>
+  </property>
+  {% endfor %}
+</configuration>

--- a/tdp_vars_defaults/spark/spark.yml
+++ b/tdp_vars_defaults/spark/spark.yml
@@ -53,6 +53,15 @@ spark_defaults_client:
   spark.hadoop.yarn.timeline-service.enabled: "false"
   spark.yarn.historyServer.address: "{{ groups['spark_hs'][0] | tosit.tdp.access_fqdn(hostvars) }}:18081"
   spark.master: yarn
+  # Hive configuration 
+  spark.datasource.hive.warehouse.metastoreUri: thrift://{{ groups['hive_ms'][0] | tosit.tdp.access_fqdn(hostvars) }}:9083
+  spark.hadoop.hive.zookeeper.quorum: |
+    {{ groups['zk'] | 
+      map('tosit.tdp.access_fqdn', hostvars) |
+      map('regex_replace', '^(.*)$', '\1:2181') |
+      list |
+      join(',') | trim }}
+  spark.sql.hive.metastore.jars: /opt/tdp/hive/lib/*
 
 # spark-default.conf - Spark History Server
 spark_defaults_hs:
@@ -84,6 +93,24 @@ spark_env_hs:
 
 # spark-env.sh - Spark Client
 spark_env_client:
+
+# hive-site.xml - spark client
+hive_site_spark:
+  hive.metastore.uris: thrift://{{ groups['hive_ms'][0] | tosit.tdp.access_fqdn(hostvars) }}:9083
+  hive.exec.scratchdir: /tmp/spark
+  hive.metastore.client.connect.retry.delay: 5
+  hive.metastore.client.socket.timeout: 1800
+  hive.server2.enable.doAs: "false"
+  hive.server2.thrift.port: 10016
+  hive.server2.transport.mode: http
+  hive.metastore.sasl.enabled: "true"
+  hadoop.security.authentication: kerberos
+  hive.metastore.use.SSL: "true"
+  hive.metastore.truststore.path: "{{ spark_truststore_location }}"
+  hive.metastore.truststore.password: "{{ spark_truststore_password }}"
+  hive.metastore.kerberos.principal: "hive_ms/_HOST@{{ realm }}"
+  hive.metastore.execute.setugi: "true"
+  hadoop.rpc.protection: AUTHENTICATION
 
 # Service restart policies
 spark_hs_restart: "no"

--- a/tdp_vars_defaults/spark3/spark3.yml
+++ b/tdp_vars_defaults/spark3/spark3.yml
@@ -53,6 +53,15 @@ spark_defaults_client:
   spark.hadoop.yarn.timeline-service.enabled: "false"
   spark.yarn.historyServer.address: "{{ groups['spark3_hs'][0] | tosit.tdp.access_fqdn(hostvars) }}:18081"
   spark.master: yarn
+  # Hive configuration 
+  spark.datasource.hive.warehouse.metastoreUri: thrift://{{ groups['hive_ms'][0] | tosit.tdp.access_fqdn(hostvars) }}:9083
+  spark.hadoop.hive.zookeeper.quorum: |
+    {{ groups['zk'] | 
+      map('tosit.tdp.access_fqdn', hostvars) |
+      map('regex_replace', '^(.*)$', '\1:2181') |
+      list |
+      join(',') | trim }}
+  spark.sql.hive.metastore.jars: /opt/tdp/hive/lib/*
 
 # spark-default.conf - Spark History Server
 spark_defaults_hs:
@@ -87,3 +96,21 @@ spark_env_client:
 
 # Service restart policies
 spark_hs_restart: "no"
+
+# hive-site.xml - spark client
+hive_site_spark:
+  hive.metastore.uris: thrift://{{ groups['hive_ms'][0] | tosit.tdp.access_fqdn(hostvars) }}:9083
+  hive.exec.scratchdir: /tmp/spark
+  hive.metastore.client.connect.retry.delay: 5
+  hive.metastore.client.socket.timeout: 1800
+  hive.server2.enable.doAs: "false"
+  hive.server2.thrift.port: 10016
+  hive.server2.transport.mode: http
+  hive.metastore.sasl.enabled: "true"
+  hadoop.security.authentication: kerberos
+  hive.metastore.use.SSL: "true"
+  hive.metastore.truststore.path: "{{ spark_truststore_location }}"
+  hive.metastore.truststore.password: "{{ spark_truststore_password }}"
+  hive.metastore.kerberos.principal: "hive_ms/_HOST@{{ realm }}"
+  hive.metastore.execute.setugi: "true"
+  hadoop.rpc.protection: AUTHENTICATION


### PR DESCRIPTION
<!--  Thank you for sending a pull request! Please make sure:

1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes:
<!--
Example: "Fixes #(issue number)" or "Fixes (link of issue)".
-->
Fixes #284 

Thanks to this new feature, you can use HiveSQL from different spark-clients.

e.g. : 
```
hive@mehdi-edge-01 ~]$ spark3-shell 
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
2022-05-24 16:38:25,266 WARN yarn.Client: Neither spark.yarn.jars nor spark.yarn.archive is set, falling back to uploading libraries under SPARK_HOME.
Spark context Web UI available at http://mehdi-edge-01.novalocal:4040
Spark context available as 'sc' (master = yarn, app id = application_1652347047958_0126).
Spark session available as 'spark'.
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /___/ .__/\_,_/_/ /_/\_\   version 3.2.2-TDP-0.1.0-SNAPSHOT
      /_/
         
Using Scala version 2.12.15 (OpenJDK 64-Bit Server VM, Java 1.8.0_322)
Type in expressions to have them evaluated.
Type :help for more information.

scala> 

scala> sql("select avg(col1) from table1").show()
Hive Session ID = 85fe5684-04f2-4575-bf33-718a39b3e0e2
[Stage 0:>                                                          (0 + 2                                                                          +---------+
|avg(col1)|
+---------+
|      1.5|
+---------+
```



#### Additional comments:
<!--
Example: `"I was not sure if it is the right way to do but..."
-->

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to [TOSIT](https://www.tosit.io/),
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.

