### PR TITLE
fix: ensure mapred pid dir persists restart

### DIFF
--- a/roles/yarn/common/templates/tmpfiles-hadoop-mapred.conf.j2
+++ b/roles/yarn/common/templates/tmpfiles-hadoop-mapred.conf.j2
@@ -1,0 +1,1 @@
+d {{ hadoop_mapred_pid_dir }} 0755 {{ mapred_user }} {{ hadoop_group }} -

--- a/roles/yarn/jobhistoryserver/tasks/install.yml
+++ b/roles/yarn/jobhistoryserver/tasks/install.yml
@@ -13,6 +13,11 @@
     group: '{{ hadoop_group }}'
     owner: '{{ mapred_user }}'
 
+- name: Template hadoop mapred tmpfiles.d
+  template:
+    src: tmpfiles-hadoop-mapred.conf.j2
+    dest: /etc/tmpfiles.d/hadoop-mapred.conf
+
 - name: Template hadoop yarn tmpfiles.d
   template:
     src: tmpfiles-hadoop-yarn.conf.j2


### PR DESCRIPTION
Fixes #296 [`/run/hadoop/mapred` directory not created on boot](https://github.com/TOSIT-IO/tdp-collection/issues/296)

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to [TOSIT](https://www.tosit.io/),
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.

