### PR TITLE
fix:  add tmpfiles.d for spark

### DIFF
--- a/roles/spark/common/tasks/install.yml
+++ b/roles/spark/common/tasks/install.yml
@@ -36,6 +36,11 @@
     group: "{{ hadoop_group }}"
     owner: "{{ spark_user }}"
 
+- name: Template spark tmpfiles.d
+  template:
+    src: tmpfiles-spark.conf.j2
+    dest: "/etc/tmpfiles.d/{{ spark_version }}.conf"
+
 - name: Create log directory
   file:
     path: "{{ spark_log_dir }}"

--- a/roles/spark/common/templates/tmpfiles-spark.conf.j2
+++ b/roles/spark/common/templates/tmpfiles-spark.conf.j2
@@ -1,0 +1,1 @@
+d {{ spark_pid_dir }} 0755 {{ spark_user }} {{ hadoop_group }} -


### PR DESCRIPTION
Fixes #309 

#### Additional comments:
I parameterized the `/etc/tmpfiles.d/{{ spark_version }}.conf` filename because both Spark2 and Spark3 dual deployment would overwrite each others pid file because they both use the same variable `spark_pid_dir`.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to [TOSIT](https://www.tosit.io/),
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.

