### PR TITLE
fix(hdfs): create HDFS Datanode parent data dirs

### DIFF
--- a/roles/hdfs/datanode/tasks/install.yml
+++ b/roles/hdfs/datanode/tasks/install.yml
@@ -6,6 +6,12 @@
     name: tosit.tdp.hdfs.common
     tasks_from: install
 
+- name: Create HDFS Datanode parent directories
+  file:
+    path: "{{ item | dirname }}"
+    state: directory
+  loop: "{{ hdfs_site['dfs.datanode.data.dir'].split(',') }}"
+
 - name: Create HDFS Datanode directory
   file:
     path: "{{ item }}"


### PR DESCRIPTION
Use default owner, group and mode for HDFS Datanode parent data dirs.

<!--  Thank you for sending a pull request! Please make sure:

1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes:
<!--
Example: "Fixes #(issue number)" or "Fixes (link of issue)".
-->
Fixes #346 

#### Additional comments:
<!--
Example: `"I was not sure if it is the right way to do but..."
-->

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to [TOSIT](https://www.tosit.io/),
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.

