### PR TITLE
kms: add ranger kms service to tdp-collection

### DIFF
--- a/playbooks/meta/all.yml
+++ b/playbooks/meta/all.yml
@@ -35,10 +35,15 @@
 - import_playbook: ../ranger_admin_config.yml
 - import_playbook: ../ranger_admin_start.yml
 # ranger_admin_init
+- import_playbook: ../ranger_kms_install.yml
 # ranger_install
+- import_playbook: ../ranger_kms_config.yml
+- import_playbook: ../ranger_kms_hdfs.yml
 - import_playbook: ../ranger_usersync_config.yml
 # ranger_config
 - import_playbook: ../ranger_usersync_start.yml
+- import_playbook: ../ranger_kms_init.yml
+- import_playbook: ../ranger_kms_start.yml
 # ranger_start
 # ranger_init
 - import_playbook: ../hdfs_client_install.yml

--- a/playbooks/meta/ranger.yml
+++ b/playbooks/meta/ranger.yml
@@ -10,9 +10,14 @@
 - import_playbook: ../ranger_admin_config.yml
 - import_playbook: ../ranger_admin_start.yml
 # ranger_admin_init
+- import_playbook: ../ranger_kms_install.yml
 # ranger_install
+- import_playbook: ../ranger_kms_config.yml
+- import_playbook: ../ranger_kms_hdfs.yml
 - import_playbook: ../ranger_usersync_config.yml
 # ranger_config
 - import_playbook: ../ranger_usersync_start.yml
+- import_playbook: ../ranger_kms_init.yml
+- import_playbook: ../ranger_kms_start.yml
 # ranger_start
 # ranger_init

--- a/playbooks/ranger_jmx-exporter_config.yml
+++ b/playbooks/ranger_jmx-exporter_config.yml
@@ -20,3 +20,12 @@
         name: tosit.tdp.ranger.usersync
         tasks_from: jmx-exporter
     - meta: clear_facts
+- name: jmx-exporter Ranger KMS config
+  hosts: ranger_kms
+  tasks:
+    - tosit.tdp.resolve:
+        node_name: ranger_jmx-exporter
+    - import_role:
+        name: tosit.tdp.ranger.kms
+        tasks_from: jmx-exporter
+    - meta: clear_facts

--- a/playbooks/ranger_kerberos_install.yml
+++ b/playbooks/ranger_kerberos_install.yml
@@ -22,3 +22,13 @@
         name: tosit.tdp.ranger.usersync
         tasks_from: kerberos
     - meta: clear_facts
+- name: Kerberos Ranger KMS install
+  hosts: ranger_kms
+  strategy: linear
+  tasks:
+    - tosit.tdp.resolve:
+        node_name: ranger_kerberos
+    - import_role:
+        name: tosit.tdp.ranger.kms
+        tasks_from: kerberos
+    - meta: clear_facts

--- a/playbooks/ranger_kms_config.yml
+++ b/playbooks/ranger_kms_config.yml
@@ -1,0 +1,13 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Config Ranger KMS
+  hosts: ranger_kms
+  tasks:
+    - tosit.tdp.resolve:
+        node_name: ranger_kms
+    - import_role:
+        name: tosit.tdp.ranger.kms
+        tasks_from: config
+    - meta: clear_facts

--- a/playbooks/ranger_kms_hdfs.yml
+++ b/playbooks/ranger_kms_hdfs.yml
@@ -1,0 +1,13 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: HDFS Ranger KMS
+  hosts: ranger_kms
+  tasks:
+    - tosit.tdp.resolve:
+        node_name: ranger_kms
+    - import_role:
+        name: tosit.tdp.ranger.kms
+        tasks_from: hdfs
+    - meta: clear_facts

--- a/playbooks/ranger_kms_init.yml
+++ b/playbooks/ranger_kms_init.yml
@@ -1,0 +1,13 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Init Ranger KMS
+  hosts: ranger_kms
+  tasks:
+    - tosit.tdp.resolve:
+        node_name: ranger_kms
+    - import_role:
+        name: tosit.tdp.ranger.kms
+        tasks_from: init
+    - meta: clear_facts

--- a/playbooks/ranger_kms_install.yml
+++ b/playbooks/ranger_kms_install.yml
@@ -1,0 +1,13 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Install Ranger KMS
+  hosts: ranger_kms
+  tasks:
+    - tosit.tdp.resolve:
+        node_name: ranger_kms
+    - import_role:
+        name: tosit.tdp.ranger.kms
+        tasks_from: install
+    - meta: clear_facts

--- a/playbooks/ranger_kms_kerberos.yml
+++ b/playbooks/ranger_kms_kerberos.yml
@@ -1,0 +1,13 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Kerberos Ranger KMS
+  hosts: ranger_kms
+  tasks:
+    - tosit.tdp.resolve:
+        node_name: ranger_kms
+    - import_role:
+        name: tosit.tdp.ranger.kms
+        tasks_from: kerberos
+    - meta: clear_facts

--- a/playbooks/ranger_kms_restart.yml
+++ b/playbooks/ranger_kms_restart.yml
@@ -1,0 +1,13 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Restart Ranger KMS
+  hosts: ranger_kms
+  tasks:
+    - tosit.tdp.resolve:
+        node_name: ranger_kms
+    - import_role:
+        name: tosit.tdp.ranger.kms
+        tasks_from: restart
+    - meta: clear_facts

--- a/playbooks/ranger_kms_ssl-tls.yml
+++ b/playbooks/ranger_kms_ssl-tls.yml
@@ -1,0 +1,13 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: SSL-TLS Ranger KMS
+  hosts: ranger_kms
+  tasks:
+    - tosit.tdp.resolve:
+        node_name: ranger_kms
+    - import_role:
+        name: tosit.tdp.ranger.kms
+        tasks_from: ssl-tls
+    - meta: clear_facts

--- a/playbooks/ranger_kms_start.yml
+++ b/playbooks/ranger_kms_start.yml
@@ -1,0 +1,13 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Start Ranger KMS
+  hosts: ranger_kms
+  tasks:
+    - tosit.tdp.resolve:
+        node_name: ranger_kms
+    - import_role:
+        name: tosit.tdp.ranger.kms
+        tasks_from: start
+    - meta: clear_facts

--- a/playbooks/ranger_kms_stop.yml
+++ b/playbooks/ranger_kms_stop.yml
@@ -1,0 +1,13 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Stop Ranger KMS
+  hosts: ranger_kms
+  tasks:
+    - tosit.tdp.resolve:
+        node_name: ranger_kms
+    - import_role:
+        name: tosit.tdp.ranger.kms
+        tasks_from: stop
+    - meta: clear_facts

--- a/playbooks/ranger_ssl-tls_install.yml
+++ b/playbooks/ranger_ssl-tls_install.yml
@@ -20,3 +20,11 @@
         name: tosit.tdp.ranger.usersync
         tasks_from: ssl-tls
     - meta: clear_facts
+- name: SSL-TLS Ranger KMS install
+  hosts: ranger_kms
+  tasks:
+    - tosit.tdp.resolve:
+        node_name: ranger_ssl-tls
+    - import_role:
+        name: tosit.tdp.ranger.kms
+        tasks_from: ssl-tls

--- a/roles/hdfs/datanode/tasks/ssl-tls.yml
+++ b/roles/hdfs/datanode/tasks/ssl-tls.yml
@@ -20,3 +20,11 @@
   vars:
     truststore_location: "{{ hadoop_truststore_location }}"
     truststore_password: "{{ hadoop_truststore_password }}"
+
+- include_role:
+    name: tosit.tdp.utils.ssl_tls
+    tasks_from: verify_truststore
+  vars:
+    truststore_location: "/etc/pki/java/cacerts"
+    truststore_password: "changeit"
+    alias: "root_ca"

--- a/roles/ranger/common/tasks/install.yml
+++ b/roles/ranger/common/tasks/install.yml
@@ -24,3 +24,16 @@
     state: directory
     group: '{{ hadoop_group }}'
     owner: '{{ ranger_user }}'
+
+- include_role:
+    name: tosit.tdp.utils.user
+  vars:
+    user: "{{ ranger_kms_user }}"
+    group: "{{ hadoop_group }}"
+
+- name: Create Ranger KMS config directory
+  file:
+    path: '{{ ranger_kms_conf_dir }}'
+    state: directory
+    group: '{{ hadoop_group }}'
+    owner: '{{ ranger_kms_user }}'

--- a/roles/ranger/common/templates/kms-site.xml.j2
+++ b/roles/ranger/common/templates/kms-site.xml.j2
@@ -260,4 +260,34 @@ DEFAULT
   	<value>*</value>
   </property>
 
+  <property>
+  	<name>hadoop.kms.proxyuser.yarn.groups</name>
+  	<value>*</value>
+  </property>
+  
+  <property>
+  	<name>hadoop.kms.proxyuser.yarn.hosts</name>
+  	<value>*</value>
+  </property>
+  
+  <property>
+  	<name>hadoop.kms.proxyuser.yarn.users</name>
+  	<value>*</value>
+  </property>
+
+  <property>
+  	<name>hadoop.kms.proxyuser.hive.groups</name>
+  	<value>*</value>
+  </property>
+  
+  <property>
+  	<name>hadoop.kms.proxyuser.hive.hosts</name>
+  	<value>*</value>
+  </property>
+  
+  <property>
+  	<name>hadoop.kms.proxyuser.hive.users</name>
+  	<value>*</value>
+  </property>
+
 </configuration>

--- a/roles/ranger/common/templates/kms-site.xml.j2
+++ b/roles/ranger/common/templates/kms-site.xml.j2
@@ -98,7 +98,7 @@
 
   <property>
     <name>hadoop.kms.authentication.kerberos.principal</name>
-    <value>HTTP/{{ groups['ranger_kms'][0] | tosit.tdp.access_fqdn(hostvars) }}@TDP.LOCAL</value>
+    <value>HTTP/{{ ansible_fqdn }}@{{ realm }}</value>
     <description>
       The Kerberos principal to use for the HTTP endpoint.
       The principal must start with 'HTTP/' as per the Kerberos HTTP SPNEGO specification.
@@ -108,14 +108,14 @@
   <property>
     <name>hadoop.kms.authentication.kerberos.name.rules</name>
 
-    <value>RULE:[2:$1/$2@$0]([ndj]n/.*@TDP.LOCAL)s/.*/hdfs/
-RULE:[2:$1/$2@$0]([rn]m/.*@TDP.LOCAL)s/.*/yarn/
-RULE:[2:$1/$2@$0](jhs/.*@TDP.LOCAL)s/.*/mapred/
-RULE:[2:$1/$2@$0](hive/.*@TDP.LOCAL)s/.*/hive/
-RULE:[2:$1/$2@$0](HTTP/.*@TDP.LOCAL)s/.*/HTTP/
-RULE:[2:$1/$2@$0](knox/.*@TDP.LOCAL)s/.*/knox/
-RULE:[2:$1/$2@$0](rangeradmin/.*@TDP.LOCAL)s/.*/rangeradmin/
-RULE:[2:$1/$2@$0](keyadmin/.*@TDP.LOCAL)s/.*/keyadmin/
+    <value>RULE:[2:$1/$2@$0]([ndj]n/.*@{{ realm }})s/.*/hdfs/
+RULE:[2:$1/$2@$0]([rn]m/.*@{{ realm }})s/.*/yarn/
+RULE:[2:$1/$2@$0](jhs/.*@{{ realm }})s/.*/mapred/
+RULE:[2:$1/$2@$0](hive/.*@{{ realm }})s/.*/hive/
+RULE:[2:$1/$2@$0](HTTP/.*@{{ realm }})s/.*/HTTP/
+RULE:[2:$1/$2@$0](knox/.*@{{ realm }})s/.*/knox/
+RULE:[2:$1/$2@$0](rangeradmin/.*@{{ realm }})s/.*/rangeradmin/
+RULE:[2:$1/$2@$0](keyadmin/.*@{{ realm }})s/.*/keyadmin/
 DEFAULT
 </value>
     <description>
@@ -127,7 +127,7 @@ DEFAULT
 
   <property>
     <name>hadoop.kms.authentication.signer.secret.provider</name>
-    <value>random</value>
+    <value>zookeeper</value>
     <description>
       Indicates how the secret to sign the authentication cookies will be
       stored. Options are 'random' (default), 'string' and 'zookeeper'.
@@ -148,7 +148,7 @@ DEFAULT
 
   <property>
     <name>hadoop.kms.authentication.signer.secret.provider.zookeeper.connection.string</name>
-    <value>#HOSTNAME#:#PORT#,...</value>
+    <value>{{ hadoop_ha_zookeeper_quorum | trim }}</value>
     <description>
       The Zookeeper connection string, a list of hostnames and port comma
       separated.
@@ -157,7 +157,7 @@ DEFAULT
 
   <property>
     <name>hadoop.kms.authentication.signer.secret.provider.zookeeper.auth.type</name>
-    <value>kerberos</value>
+    <value>sasl</value>
     <description>
       The Zookeeper authentication type, 'none' or 'sasl' (Kerberos).
     </description>
@@ -165,7 +165,7 @@ DEFAULT
 
   <property>
     <name>hadoop.kms.authentication.signer.secret.provider.zookeeper.kerberos.keytab</name>
-    <value>/etc/hadoop/conf/kms.keytab</value>
+    <value>/etc/security/keytabs/keyadmin.service.keytab</value>
     <description>
       The absolute path for the Kerberos keytab with the credentials to
       connect to Zookeeper.
@@ -174,7 +174,7 @@ DEFAULT
 
   <property>
     <name>hadoop.kms.authentication.signer.secret.provider.zookeeper.kerberos.principal</name>
-    <value>kms/#HOSTNAME#</value>
+    <value>keyadmin/{{ ansible_fqdn }}@{{ realm }}</value>
     <description>
       The Kerberos service principal used to connect to Zookeeper.
     </description>

--- a/roles/ranger/common/templates/kms-site.xml.j2
+++ b/roles/ranger/common/templates/kms-site.xml.j2
@@ -112,7 +112,10 @@
 RULE:[2:$1/$2@$0]([rn]m/.*@TDP.LOCAL)s/.*/yarn/
 RULE:[2:$1/$2@$0](jhs/.*@TDP.LOCAL)s/.*/mapred/
 RULE:[2:$1/$2@$0](hive/.*@TDP.LOCAL)s/.*/hive/
-RULE:[2:$1/$2@$0](rangeradmin/.*@TDP.LOCAL)s/.*/ranger/
+RULE:[2:$1/$2@$0](HTTP/.*@TDP.LOCAL)s/.*/HTTP/
+RULE:[2:$1/$2@$0](knox/.*@TDP.LOCAL)s/.*/knox/
+RULE:[2:$1/$2@$0](rangeradmin/.*@TDP.LOCAL)s/.*/rangeradmin/
+RULE:[2:$1/$2@$0](keyadmin/.*@TDP.LOCAL)s/.*/keyadmin/
 DEFAULT
 </value>
     <description>
@@ -183,17 +186,78 @@ DEFAULT
   </property>
   
   <property>
-  	<name>hadoop.kms.proxyuser.ranger.groups</name>
+  	<name>hadoop.kms.proxyuser.rangeradmin.groups</name>
   	<value>*</value>
   </property>
   
   <property>
-  	<name>hadoop.kms.proxyuser.ranger.hosts</name>
+  	<name>hadoop.kms.proxyuser.rangeradmin.hosts</name>
   	<value>*</value>
   </property>
   
   <property>
-  	<name>hadoop.kms.proxyuser.ranger.users</name>
+  	<name>hadoop.kms.proxyuser.rangeradmin.users</name>
   	<value>*</value>
   </property>
+
+  <property>
+  	<name>hadoop.kms.proxyuser.hdfs.groups</name>
+  	<value>*</value>
+  </property>
+  
+  <property>
+  	<name>hadoop.kms.proxyuser.hdfs.hosts</name>
+  	<value>*</value>
+  </property>
+  
+  <property>
+  	<name>hadoop.kms.proxyuser.hdfs.users</name>
+  	<value>*</value>
+  </property>
+
+  <property>
+  	<name>hadoop.kms.proxyuser.HTTP.groups</name>
+  	<value>*</value>
+  </property>
+  
+  <property>
+  	<name>hadoop.kms.proxyuser.HTTP.hosts</name>
+  	<value>*</value>
+  </property>
+  
+  <property>
+  	<name>hadoop.kms.proxyuser.HTTP.users</name>
+  	<value>*</value>
+  </property>
+
+  <property>
+  	<name>hadoop.kms.proxyuser.knox.groups</name>
+  	<value>*</value>
+  </property>
+  
+  <property>
+  	<name>hadoop.kms.proxyuser.knox.hosts</name>
+  	<value>*</value>
+  </property>
+  
+  <property>
+  	<name>hadoop.kms.proxyuser.knox.users</name>
+  	<value>*</value>
+  </property>
+
+  <property>
+  	<name>hadoop.kms.proxyuser.keyadmin.groups</name>
+  	<value>*</value>
+  </property>
+  
+  <property>
+  	<name>hadoop.kms.proxyuser.keyadmin.hosts</name>
+  	<value>*</value>
+  </property>
+  
+  <property>
+  	<name>hadoop.kms.proxyuser.keyadmin.users</name>
+  	<value>*</value>
+  </property>
+
 </configuration>

--- a/roles/ranger/common/templates/kms-site.xml.j2
+++ b/roles/ranger/common/templates/kms-site.xml.j2
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<configuration>
+
+  <!-- KMS Backend KeyProvider -->
+
+  <property>
+    <name>hadoop.kms.key.provider.uri</name>
+    <value>dbks://http@localhost:9292/kms</value>
+    <description>
+      URI of the backing KeyProvider for the KMS.
+    </description>
+  </property>
+
+  <property>
+    <name>hadoop.security.keystore.JavaKeyStoreProvider.password</name>
+    <value>none</value>
+    <description>
+      If using the JavaKeyStoreProvider, the password for the keystore file.
+    </description>
+  </property>
+  
+  <!-- KMS Cache -->
+
+  <property>
+    <name>hadoop.kms.cache.enable</name>
+    <value>true</value>
+    <description>
+      Whether the KMS will act as a cache for the backing KeyProvider.
+      When the cache is enabled, operations like getKeyVersion, getMetadata,
+      and getCurrentKey will sometimes return cached data without consulting
+      the backing KeyProvider. Cached values are flushed when keys are deleted
+      or modified.
+    </description>
+  </property>
+
+  <property>
+    <name>hadoop.kms.cache.timeout.ms</name>
+    <value>600000</value>
+    <description>
+      Expiry time for the KMS key version and key metadata cache, in
+      milliseconds. This affects getKeyVersion and getMetadata.
+    </description>
+  </property>
+
+  <property>
+    <name>hadoop.kms.current.key.cache.timeout.ms</name>
+    <value>30000</value>
+    <description>
+      Expiry time for the KMS current key cache, in milliseconds. This
+      affects getCurrentKey operations.
+    </description>
+  </property>
+
+  <!-- KMS Audit -->
+
+  <property>
+    <name>hadoop.kms.audit.aggregation.window.ms</name>
+    <value>10000</value>
+    <description>
+      Duplicate audit log events within the aggregation window (specified in
+      ms) are quashed to reduce log traffic. A single message for aggregated
+      events is printed at the end of the window, along with a count of the
+      number of aggregated events.
+    </description>
+  </property>
+
+  <!-- KMS Security -->
+
+  <property>
+    <name>hadoop.kms.authentication.type</name>
+    <value>kerberos</value>
+    <description>
+      Authentication type for the KMS. Can be either &quot;simple&quot;
+      or &quot;kerberos&quot;.
+    </description>
+  </property>
+
+  <property>
+    <name>hadoop.kms.authentication.kerberos.keytab</name>
+    <value>/etc/security/keytabs/spnego.service.keytab</value>
+    <description>
+      Path to the keytab with credentials for the configured Kerberos principal.
+    </description>
+  </property>
+
+  <property>
+    <name>hadoop.kms.authentication.kerberos.principal</name>
+    <value>HTTP/{{ groups['ranger_kms'][0] | tosit.tdp.access_fqdn(hostvars) }}@TDP.LOCAL</value>
+    <description>
+      The Kerberos principal to use for the HTTP endpoint.
+      The principal must start with 'HTTP/' as per the Kerberos HTTP SPNEGO specification.
+    </description>
+  </property>
+
+  <property>
+    <name>hadoop.kms.authentication.kerberos.name.rules</name>
+
+    <value>RULE:[2:$1/$2@$0]([ndj]n/.*@TDP.LOCAL)s/.*/hdfs/
+RULE:[2:$1/$2@$0]([rn]m/.*@TDP.LOCAL)s/.*/yarn/
+RULE:[2:$1/$2@$0](jhs/.*@TDP.LOCAL)s/.*/mapred/
+RULE:[2:$1/$2@$0](hive/.*@TDP.LOCAL)s/.*/hive/
+RULE:[2:$1/$2@$0](rangeradmin/.*@TDP.LOCAL)s/.*/ranger/
+DEFAULT
+</value>
+    <description>
+      Rules used to resolve Kerberos principal names.
+    </description>
+  </property>
+
+  <!-- Authentication cookie signature source -->
+
+  <property>
+    <name>hadoop.kms.authentication.signer.secret.provider</name>
+    <value>random</value>
+    <description>
+      Indicates how the secret to sign the authentication cookies will be
+      stored. Options are 'random' (default), 'string' and 'zookeeper'.
+      If using a setup with multiple KMS instances, 'zookeeper' should be used.
+    </description>
+  </property>
+
+  <!-- Configuration for 'zookeeper' authentication cookie signature source -->
+
+  <property>
+    <name>hadoop.kms.authentication.signer.secret.provider.zookeeper.path</name>
+    <value>/hadoop-kms/hadoop-auth-signature-secret</value>
+    <description>
+      The Zookeeper ZNode path where the KMS instances will store and retrieve
+      the secret from.
+    </description>
+  </property>
+
+  <property>
+    <name>hadoop.kms.authentication.signer.secret.provider.zookeeper.connection.string</name>
+    <value>#HOSTNAME#:#PORT#,...</value>
+    <description>
+      The Zookeeper connection string, a list of hostnames and port comma
+      separated.
+    </description>
+  </property>
+
+  <property>
+    <name>hadoop.kms.authentication.signer.secret.provider.zookeeper.auth.type</name>
+    <value>kerberos</value>
+    <description>
+      The Zookeeper authentication type, 'none' or 'sasl' (Kerberos).
+    </description>
+  </property>
+
+  <property>
+    <name>hadoop.kms.authentication.signer.secret.provider.zookeeper.kerberos.keytab</name>
+    <value>/etc/hadoop/conf/kms.keytab</value>
+    <description>
+      The absolute path for the Kerberos keytab with the credentials to
+      connect to Zookeeper.
+    </description>
+  </property>
+
+  <property>
+    <name>hadoop.kms.authentication.signer.secret.provider.zookeeper.kerberos.principal</name>
+    <value>kms/#HOSTNAME#</value>
+    <description>
+      The Kerberos service principal used to connect to Zookeeper.
+    </description>
+  </property>
+  
+  <property>
+  	<name>hadoop.kms.security.authorization.manager</name>
+  	<value>org.apache.ranger.authorization.kms.authorizer.RangerKmsAuthorizer</value>
+  </property>
+  
+  <property>
+  	<name>hadoop.kms.proxyuser.ranger.groups</name>
+  	<value>*</value>
+  </property>
+  
+  <property>
+  	<name>hadoop.kms.proxyuser.ranger.hosts</name>
+  	<value>*</value>
+  </property>
+  
+  <property>
+  	<name>hadoop.kms.proxyuser.ranger.users</name>
+  	<value>*</value>
+  </property>
+</configuration>

--- a/roles/ranger/common/templates/kms_install.properties.j2
+++ b/roles/ranger/common/templates/kms_install.properties.j2
@@ -1,0 +1,257 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# This file provides a list of the deployment variables for the Ranger KMS Web Application 
+#
+
+#------------------------- DB CONFIG - BEGIN ----------------------------------
+# Uncomment the below if the DBA steps need to be run separately
+setup_mode={{ kms_install_properties.setup_mode }} 
+
+PYTHON_COMMAND_INVOKER=python2
+
+#DB_FLAVOR=MYSQL|ORACLE|POSTGRES|MSSQL|SQLA
+DB_FLAVOR={{ kms_install_properties.DB_FLAVOR }}
+
+#
+# Location of DB client library (please check the location of the jar file)
+#
+#SQL_CONNECTOR_JAR=/usr/share/java/ojdbc6.jar
+#SQL_CONNECTOR_JAR=/usr/share/java/mysql-connector-java.jar
+#SQL_CONNECTOR_JAR=/usr/share/java/postgresql.jar
+#SQL_CONNECTOR_JAR=/usr/share/java/sqljdbc4.jar
+#SQL_CONNECTOR_JAR=/opt/sqlanywhere17/java/sajdbc4.jar
+SQL_CONNECTOR_JAR={{ kms_install_properties.SQL_CONNECTOR_JAR }}
+
+
+#
+# DB password for the DB admin user-id
+# **************************************************************************
+# ** If the password is left empty or not-defined here, 
+# ** it will be prompted to enter the password during installation process 
+# **************************************************************************
+#
+#db_root_user=root|SYS|postgres|sa|dba
+#db_host=host:port              # for DB_FLAVOR=MYSQL|POSTGRES|SQLA|MSSQL       #for example: db_host=localhost:3306
+#db_host=host:port:SID          # for DB_FLAVOR=ORACLE                          #for SID example: db_host=localhost:1521:ORCL
+#db_host=host:port/ServiceName  # for DB_FLAVOR=ORACLE                          #for Service example: db_host=localhost:1521/XE
+#db_host=host:port:GL           # for DB_FLAVOR=ORACLE                          #for TNSNAME example: db_host=localhost:1521:GL
+db_root_user=root
+db_root_password=
+db_host={{ kms_install_properties.db_host }}
+db_ssl_enabled=false
+db_ssl_required=false
+db_ssl_verifyServerCertificate=false
+#db_ssl_auth_type=1-way|2-way, where 1-way represents standard one way ssl authentication and 2-way represents mutual ssl authentication
+db_ssl_auth_type=2-way
+javax_net_ssl_keyStore=
+javax_net_ssl_keyStorePassword=
+javax_net_ssl_trustStore=
+javax_net_ssl_trustStorePassword=
+#
+# DB UserId used for the Ranger KMS schema
+#
+db_name={{ kms_install_properties.db_name }}
+db_user={{ kms_install_properties.db_user }}
+db_password={{ kms_install_properties.db_password }}
+
+#------------------------- DB CONFIG - END ----------------------------------
+#KMS Server config
+ranger_kms_http_enabled=false
+ranger_kms_https_keystore_file={{ ranger_keystore_location }}
+ranger_kms_https_keystore_keyalias={{ ansible_fqdn }}
+ranger_kms_https_keystore_password={{ ranger_keystore_password }}
+
+#------------------------- RANGER KMS Master Key Crypt Key ------------------
+KMS_MASTER_KEY_PASSWD={{ ranger_keyadmin_password }}
+
+#------------------------- Ranger KMS Kerberos Configuration ---------------------------
+kms_principal=keyadmin/{{ ansible_fqdn }}@{{ realm }}
+kms_keytab=/etc/security/keytabs/keyadmin.service.keytab
+hadoop_conf=/etc/hadoop/conf
+
+#------------------------- Ranger KMS HSM CONFIG ------------------------------
+HSM_TYPE=LunaProvider
+HSM_ENABLED=false
+HSM_PARTITION_NAME=par19
+HSM_PARTITION_PASSWORD=S@fenet123
+
+#------------------------- Ranger SAFENET KEYSECURE CONFIG ------------------------------
+KEYSECURE_ENABLED=false
+KEYSECURE_USER_PASSWORD_AUTHENTICATION=true
+KEYSECURE_MASTERKEY_NAME=safenetkeysecure
+KEYSECURE_USERNAME=user1
+KEYSECURE_PASSWORD=t1e2s3t4
+KEYSECURE_HOSTNAME=SunPKCS11-keysecurehn
+KEYSECURE_MASTER_KEY_SIZE=256
+KEYSECURE_LIB_CONFIG_PATH=/opt/safenetConf/64/8.3.1/sunpkcs11.cfg
+
+#
+# ------- UNIX User CONFIG ----------------
+#
+unix_user={{ ranger_kms_user }}
+unix_user_pwd={{ ranger_kms_user }}
+unix_group={{ hadoop_group }}
+#
+# ------- UNIX User CONFIG  - END ----------------
+#
+
+#
+# ------- 
+#
+
+# Location of Policy Manager URL 
+#
+# Example:
+# POLICY_MGR_URL=http://policymanager.xasecure.net:6080
+#
+POLICY_MGR_URL={{ kms_install_properties.POLICY_MGR_URL }}
+
+#
+# This is the repository name created within policy manager
+#
+# Example:
+# REPOSITORY_NAME=kmsdev
+#
+REPOSITORY_NAME={{ kms_install_properties.REPOSITORY_NAME }}
+
+# AUDIT configuration with V3 properties
+
+#Should audit be summarized at source
+XAAUDIT.SUMMARY.ENABLE=false
+
+# Enable audit logs to Solr
+#Example
+#XAAUDIT.SOLR.ENABLE=true
+#XAAUDIT.SOLR.URL=http://localhost:6083/solr/ranger_audits
+#XAAUDIT.SOLR.ZOOKEEPER=
+#XAAUDIT.SOLR.FILE_SPOOL_DIR=/var/log/ranger/kms/audit/solr/spool
+
+XAAUDIT.SOLR.ENABLE={{ kms_install_properties.XAAUDIT_SOLR_ENABLE }}
+XAAUDIT.SOLR.URL={{ kms_install_properties.XAAUDIT_SOLR_URL }}
+XAAUDIT.SOLR.USER=NONE
+XAAUDIT.SOLR.PASSWORD=NONE
+XAAUDIT.SOLR.ZOOKEEPER=NONE
+XAAUDIT.SOLR.FILE_SPOOL_DIR=/var/log/ranger/kms/audit/solr/spool
+
+# Enable audit logs to HDFS
+#Example
+#XAAUDIT.HDFS.ENABLE=true
+#XAAUDIT.HDFS.HDFS_DIR=hdfs://node-1.example.com:8020/ranger/audit
+#  If using Azure Blob Storage
+#XAAUDIT.HDFS.HDFS_DIR=wasb[s]://<containername>@<accountname>.blob.core.windows.net/<path>
+#XAAUDIT.HDFS.HDFS_DIR=wasb://ranger_audit_container@my-azure-account.blob.core.windows.net/ranger/audit
+#XAAUDIT.HDFS.FILE_SPOOL_DIR=/var/log/ranger/kms/audit/hdfs/spool
+
+XAAUDIT.HDFS.ENABLE=false
+XAAUDIT.HDFS.HDFS_DIR=hdfs://__REPLACE__NAME_NODE_HOST:8020/ranger/audit
+XAAUDIT.HDFS.FILE_SPOOL_DIR=/var/log/ranger/kms/audit/hdfs/spool
+
+# Following additional propertis are needed When auditing to Azure Blob Storage via HDFS
+# Get these values from your /etc/hadoop/conf/core-site.xml
+#XAAUDIT.HDFS.HDFS_DIR=wasb[s]://<containername>@<accountname>.blob.core.windows.net/<path>
+XAAUDIT.HDFS.AZURE_ACCOUNTNAME=__REPLACE_AZURE_ACCOUNT_NAME
+XAAUDIT.HDFS.AZURE_ACCOUNTKEY=__REPLACE_AZURE_ACCOUNT_KEY
+XAAUDIT.HDFS.AZURE_SHELL_KEY_PROVIDER=__REPLACE_AZURE_SHELL_KEY_PROVIDER
+XAAUDIT.HDFS.AZURE_ACCOUNTKEY_PROVIDER=__REPLACE_AZURE_ACCOUNT_KEY_PROVIDER
+
+# End of V3 properties
+
+
+#
+#  Audit to HDFS Configuration
+#
+# If XAAUDIT.HDFS.IS_ENABLED is set to true, please replace tokens
+# that start with __REPLACE__ with appropriate values
+#  XAAUDIT.HDFS.IS_ENABLED=true
+#  XAAUDIT.HDFS.DESTINATION_DIRECTORY=hdfs://__REPLACE__NAME_NODE_HOST:8020/ranger/audit/%app-type%/%time:yyyyMMdd%
+#  XAAUDIT.HDFS.LOCAL_BUFFER_DIRECTORY=__REPLACE__LOG_DIR/kms/audit
+#  XAAUDIT.HDFS.LOCAL_ARCHIVE_DIRECTORY=__REPLACE__LOG_DIR/kms/audit/archive
+#
+#
+# Example:
+#  XAAUDIT.HDFS.IS_ENABLED=true
+#  XAAUDIT.HDFS.DESTINATION_DIRECTORY=hdfs://namenode.example.com:8020/ranger/audit/%app-type%/%time:yyyyMMdd%
+#  XAAUDIT.HDFS.LOCAL_BUFFER_DIRECTORY=/var/log/kms/audit
+#  XAAUDIT.HDFS.LOCAL_ARCHIVE_DIRECTORY=/var/log/kms/audit/archive
+#
+XAAUDIT.HDFS.IS_ENABLED=false
+XAAUDIT.HDFS.DESTINATION_DIRECTORY=hdfs://__REPLACE__NAME_NODE_HOST:8020/ranger/audit/%app-type%/%time:yyyyMMdd%
+XAAUDIT.HDFS.LOCAL_BUFFER_DIRECTORY=__REPLACE__LOG_DIR/kms/audit
+XAAUDIT.HDFS.LOCAL_ARCHIVE_DIRECTORY=__REPLACE__LOG_DIR/kms/audit/archive
+
+XAAUDIT.HDFS.DESTINTATION_FILE=%hostname%-audit.log
+XAAUDIT.HDFS.DESTINTATION_FLUSH_INTERVAL_SECONDS=900
+XAAUDIT.HDFS.DESTINTATION_ROLLOVER_INTERVAL_SECONDS=86400
+XAAUDIT.HDFS.DESTINTATION_OPEN_RETRY_INTERVAL_SECONDS=60
+XAAUDIT.HDFS.LOCAL_BUFFER_FILE=%time:yyyyMMdd-HHmm.ss%.log
+XAAUDIT.HDFS.LOCAL_BUFFER_FLUSH_INTERVAL_SECONDS=60
+XAAUDIT.HDFS.LOCAL_BUFFER_ROLLOVER_INTERVAL_SECONDS=600
+XAAUDIT.HDFS.LOCAL_ARCHIVE_MAX_FILE_COUNT=10
+
+#Solr Audit Provder
+XAAUDIT.SOLR.IS_ENABLED=false
+XAAUDIT.SOLR.MAX_QUEUE_SIZE=1
+XAAUDIT.SOLR.MAX_FLUSH_INTERVAL_MS=1000
+XAAUDIT.SOLR.SOLR_URL=http://localhost:6083/solr/ranger_audits
+
+#
+# SSL Client Certificate Information
+#
+# Example:
+# SSL_KEYSTORE_FILE_PATH=/etc/ranger/kms/conf/ranger-plugin-keystore.jks
+# SSL_KEYSTORE_PASSWORD=none
+# SSL_TRUSTSTORE_FILE_PATH=/etc/ranger/kms/conf/ranger-plugin-truststore.jks
+# SSL_TRUSTSTORE_PASSWORD=none
+#
+# You do not need use SSL between agent and security admin tool, please leave these sample value as it is.
+#
+SSL_KEYSTORE_FILE_PATH={{ ranger_keystore_location }}
+SSL_KEYSTORE_PASSWORD={{ ranger_keystore_password }}
+SSL_TRUSTSTORE_FILE_PATH={{ ranger_truststore_location }}
+SSL_TRUSTSTORE_PASSWORD={{ ranger_truststore_password }}
+
+# Custom log directory path
+RANGER_KMS_LOG_DIR={{ ranger_kms_log_dir }}
+
+#PID file path
+RANGER_KMS_PID_DIR_PATH={{ ranger_kms_pid_dir }}
+# #################  DO NOT MODIFY ANY VARIABLES BELOW #########################
+#
+# --- These deployment variables are not to be modified unless you understand the full impact of the changes
+#
+################################################################################
+KMS_DIR=$PWD
+app_home=$PWD/ews/webapp
+TMPFILE=$PWD/.fi_tmp
+LOGFILE=$PWD/logfile
+
+JAVA_BIN='java'
+JAVA_VERSION_REQUIRED='1.8'
+JAVA_ORACLE='Java(TM) SE Runtime Environment'
+
+mysql_core_file=db/mysql/kms_core_db.sql
+
+oracle_core_file=db/oracle/kms_core_db_oracle.sql
+
+postgres_core_file=db/postgres/kms_core_db_postgres.sql
+
+sqlserver_core_file=db/sqlserver/kms_core_db_sqlserver.sql
+
+sqlanywhere_core_file=db/sqlanywhere/kms_core_db_sqlanywhere.sql
+cred_keystore_filename=$app_home/WEB-INF/classes/conf/.jceks/rangerkms.jceks
+
+KMS_BLACKLIST_DECRYPT_EEK=hdfs

--- a/roles/ranger/common/templates/ranger-kms.j2
+++ b/roles/ranger/common/templates/ranger-kms.j2
@@ -1,0 +1,203 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [ -z "$1" ]
+then
+	echo "Invalid argument [$1];"
+	echo "Usage: Only start | stop | restart | version, are supported."
+	echo "For KMSMetric Usage: metric -type  hsmenabled | encryptedkey | encryptedkeybyalgorithm"
+	exit;
+fi
+action=$1
+arg2=$2
+arg3=$3
+action=`echo $action | tr '[:lower:]' '[:upper:]'`
+realScriptPath=`readlink -f $0`
+realScriptDir=`dirname $realScriptPath`
+RANGER_KMS_DIR=`(cd $realScriptDir; pwd)`
+RANGER_KMS_EWS_DIR=${RANGER_KMS_DIR}/ews
+RANGER_KMS_EWS_CONF_DIR="${RANGER_KMS_EWS_DIR}/webapp/WEB-INF/classes/conf"
+RANGER_KMS_EWS_LIB_DIR="${RANGER_KMS_EWS_DIR}/webapp/WEB-INF/classes/lib"
+
+ranger_kms_max_heap_size=1g
+
+if [ -f ${RANGER_KMS_DIR}/ews/webapp/WEB-INF/classes/conf/java_home.sh ]; then
+        . ${RANGER_KMS_DIR}/ews/webapp/WEB-INF/classes/conf/java_home.sh
+fi
+
+for custom_env_script in `find ${RANGER_KMS_DIR}/ews/webapp/WEB-INF/classes/conf/ -name "ranger-kms-env*"`; do
+        if [ -f $custom_env_script ]; then
+                . $custom_env_script
+        fi
+done
+
+JMX_OPTS=" {{ jmx_common_opts }} -Dcom.sun.management.jmxremote.password.file={{ ranger_kms_conf_dir }}/conf/jmxremote.password {{ jmx_kms_exporter_ra_opts }} "
+
+JAVA_OPTS=" ${JAVA_OPTS} ${JMX_OPTS} -XX:MetaspaceSize=100m -XX:MaxMetaspaceSize=256m -Xmx${ranger_kms_max_heap_size} -Xms1g "
+
+if [ "$JAVA_HOME" != "" ]; then
+        export PATH=$JAVA_HOME/bin:$PATH
+fi
+
+cd ${RANGER_KMS_EWS_DIR}
+
+if [ -z "${RANGER_KMS_LOG_DIR}" ]
+then
+        RANGER_KMS_LOG_DIR=${RANGER_KMS_EWS_DIR}/logs
+fi
+
+if [ -z "${RANGER_KMS_PID_NAME}" ]
+then
+        RANGER_KMS_PID_NAME=rangerkms.pid
+fi
+
+if [ -z "${RANGER_KMS_PID_DIR_PATH}" ]
+then
+	RANGER_KMS_PID_DIR_PATH=/var/run/ranger_kms
+fi
+if [ ! -d "${RANGER_KMS_PID_DIR_PATH}" ]
+then
+	mkdir -p  $RANGER_KMS_PID_DIR_PATH
+	chmod 660 $RANGER_KMS_PID_DIR_PATH
+fi
+# User can set their own pid path using RANGER_KMS_PID_DIR_PATH and
+# RANGER_KMS_PID_NAME variable before calling the script. The user can modify
+# the value of the RANGER_KMS_PID_DIR_PATH in ranger-kms-env-piddir.sh to
+# change pid path and set the value of RANGER_KMS_PID_NAME to change the
+# pid file.
+pidf=${RANGER_KMS_PID_DIR_PATH}/${RANGER_KMS_PID_NAME}
+
+if [ -z "${KMS_USER}" ]
+then
+	KMS_USER=kms
+fi
+
+PROC_NAME=proc_rangerkms
+export PROC_NAME
+
+START_CLASS_NAME="org.apache.ranger.server.tomcat.EmbeddedServer"
+
+STOP_CLASS_NAME="org.apache.ranger.server.tomcat.StopEmbeddedServer"
+
+#KMS_CONFIG_FILENAME=kms_webserver.properties
+KMS_CONFIG_FILENAME=ranger-kms-site.xml
+
+TOMCAT_LOG_DIR=${RANGER_KMS_LOG_DIR}
+
+TOMCAT_LOG_FILE=${TOMCAT_LOG_DIR}/catalina.out
+TOMCAT_STOP_LOG_FILE=${TOMCAT_LOG_DIR}/stop_catalina.out
+
+if [ ! -d ${TOMCAT_LOG_DIR} ]
+then
+	mkdir -p ${TOMCAT_LOG_DIR}
+fi
+
+KMS_CONF_DIR=${RANGER_KMS_EWS_DIR}/webapp/WEB-INF/classes/conf
+SERVER_NAME=rangerkms
+JAVA_OPTS="${JAVA_OPTS} ${DB_SSL_PARAM} -Duser=${USER} -Dhostname=${HOSTNAME} -Dservername=${SERVER_NAME} -Dcatalina.base=${RANGER_KMS_EWS_DIR} -Dkms.config.dir=${KMS_CONF_DIR} -Dkms.log.dir=${TOMCAT_LOG_DIR} -cp ${RANGER_KMS_EWS_CONF_DIR}:${RANGER_KMS_EWS_LIB_DIR}/*:${RANGER_KMS_EWS_DIR}/webapp/lib/*:${JAVA_HOME}/lib/*:${RANGER_HADOOP_CONF_DIR}/*:$CLASSPATH "
+createRangerKMSPid () {
+	SLEEP_TIME_AFTER_START=5
+	nohup java -D${PROC_NAME} ${JAVA_OPTS} ${START_CLASS_NAME} ${KMS_CONFIG_FILENAME} > ${TOMCAT_LOG_FILE} 2>&1 &
+	VALUE_OF_PID=$!
+	echo "Starting Apache Ranger KMS Service"
+	sleep $SLEEP_TIME_AFTER_START
+	if ps -p $VALUE_OF_PID > /dev/null
+	then
+		echo $VALUE_OF_PID > ${pidf}
+                chown ${KMS_USER} ${pidf}
+		chmod 660 ${pidf}
+		pid=`cat $pidf`
+		echo "Apache Ranger KMS Service with pid ${pid} has started."
+	else
+		echo "Apache Ranger KMS Service failed to start"
+	fi
+	exit ;
+}
+killRangerKMSPid () {
+	WAIT_TIME_FOR_SHUTDOWN=2
+	NR_ITER_FOR_SHUTDOWN_CHECK=15
+	if [ -f "$pidf" ] ; then
+		pid=`cat $pidf` > /dev/null 2>&1
+		echo "Found Apache Ranger KMS Service with pid $pid, Stopping..."
+		nohup java ${JAVA_OPTS} ${STOP_CLASS_NAME} ${KMS_CONFIG_FILENAME} > ${TOMCAT_STOP_LOG_FILE} 2>&1
+		for ((i=0; i<$NR_ITER_FOR_SHUTDOWN_CHECK; i++))
+		do
+			sleep $WAIT_TIME_FOR_SHUTDOWN
+			if ps -p $pid > /dev/null ; then
+				echo "Shutdown in progress. Will check after $WAIT_TIME_FOR_SHUTDOWN secs again.."
+				continue;
+			else
+				break;
+			fi
+		done
+		# if process is still around, use kill -9
+		if ps -p $pid > /dev/null ; then
+			echo "Initial kill failed, getting serious now..."
+			kill -9 $pid
+		fi
+		sleep 1 # Give kill -9 sometime to "kill"
+		if ps -p $pid > /dev/null ; then
+			echo "Wow, even kill -9 failed, giving up! Sorry.."
+		else
+			rm -rf $pidf
+			echo "Apache Ranger KMS Service with pid ${pid} has been stopped."
+		fi
+	else
+		echo "Apache Ranger KMS Service is not running"
+	fi
+}
+metric(){
+  if [ "$JAVA_HOME" == "" ]; then
+    echo "[E] JAVA_HOME environment variable not defined, aborting Apache Ranger KMS metric collection" 1>&2;
+    exit 1;
+  fi
+	java  ${JAVA_OPTS} org.apache.hadoop.crypto.key.kms.server.KMSMetricUtil ${arg2} ${arg3} 2>/dev/null
+}
+if [ "${action}" == "START" ]; then
+	if [ -f "$pidf" ] ; then
+		pid=`cat $pidf`
+		if  ps -p $pid > /dev/null
+		then
+			echo "Apache Ranger KMS Service is already running [pid={$pid}]"
+			exit 1
+		else
+			rm -rf $pidf
+			createRangerKMSPid
+		fi
+	else
+		createRangerKMSPid
+	fi
+elif [ "${action}" == "STOP" ]; then
+	killRangerKMSPid
+	exit
+elif [ "${action}" == "RESTART" ]; then
+	echo "Restarting Apache Ranger KMS Service"
+	killRangerKMSPid
+	createRangerKMSPid
+	exit
+elif [ "${action}" == "METRIC" ]; then
+	metric;
+	exit
+elif [ "${action}" == "VERSION" ]; then
+	( cd ${RANGER_KMS_LIB_DIR} ; java -cp ranger-util-*.jar org.apache.ranger.common.RangerVersionInfo )
+	exit
+else
+        echo "Invalid argument [$1];"
+        echo "Usage: Only start | stop | restart | version, are supported."
+        echo "For KMSMetric Usage: metric -type  hsmenabled | encryptedkey | encryptedkeybyalgorithm"
+        exit;
+fi

--- a/roles/ranger/common/templates/ranger-kms.service.j2
+++ b/roles/ranger/common/templates/ranger-kms.service.j2
@@ -1,0 +1,15 @@
+[Unit]
+Description=Ranger KMS
+
+[Service]
+User={{ ranger_kms_user }}
+Group={{ hadoop_group }}
+Type=forking
+PIDFile={{ ranger_kms_pid_dir }}/rangerkms.pid
+ExecStart=/usr/bin/ranger-kms start
+ExecStop=/usr/bin/ranger-kms stop
+LimitNOFILE=64000
+Restart={{ ranger_kms_restart }}
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/ranger/common/templates/tmpfiles-ranger-kms.conf.j2
+++ b/roles/ranger/common/templates/tmpfiles-ranger-kms.conf.j2
@@ -1,0 +1,1 @@
+d {{ ranger_kms_pid_dir }} 0755 {{ ranger_kms_user }} {{ hadoop_group }} -

--- a/roles/ranger/kms/tasks/config.yml
+++ b/roles/ranger/kms/tasks/config.yml
@@ -1,0 +1,33 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Template install.properties
+  template:
+    src: kms_install.properties.j2
+    dest: "{{ ranger_kms_install_dir }}/install.properties"
+
+- name: Run setup.sh
+  shell: |
+    export JAVA_HOME=/usr/lib/jvm/jre-1.8.0-openjdk
+    ./setup.sh
+  args:
+    chdir: '{{ ranger_kms_install_dir }}'
+
+- name: Create symbolic link to configuration directory
+  file:
+    src: '{{ ranger_kms_install_dir }}/ews/webapp/WEB-INF/classes/conf'
+    dest: '{{ ranger_kms_conf_dir }}/conf'
+    state: link
+    group: '{{ hadoop_group }}'
+    owner: '{{ ranger_kms_user }}'
+
+- name: Template kms-site.xml
+  template:
+    src: kms-site.xml.j2
+    dest: "{{ ranger_kms_conf_dir }}/conf/kms-site.xml"
+
+- name: Render jmxremote.password
+  template:
+    src: jmxremote.password.j2
+    dest: '{{ ranger_kms_conf_dir }}/conf/jmxremote.password'

--- a/roles/ranger/kms/tasks/config.yml
+++ b/roles/ranger/kms/tasks/config.yml
@@ -31,3 +31,8 @@
   template:
     src: jmxremote.password.j2
     dest: '{{ ranger_kms_conf_dir }}/conf/jmxremote.password'
+
+- name: Render ranger-kms command
+  template:
+    src: ranger-kms.j2
+    dest: '{{ ranger_kms_install_dir }}/ranger-kms'

--- a/roles/ranger/kms/tasks/hdfs.yml
+++ b/roles/ranger/kms/tasks/hdfs.yml
@@ -1,0 +1,16 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+# Needed for HDFS path lookup in policy creation
+- name: Copy hdfs-site.xml
+  copy:
+    src: /etc/hadoop/conf/hdfs-site.xml
+    dest: '{{ ranger_kms_conf_dir }}/conf/hdfs-site.xml'
+    remote_src: yes
+
+- name: Copy core-site.xml
+  copy:
+    src: /etc/hadoop/conf/core-site.xml
+    dest: '{{ ranger_kms_conf_dir }}/conf/core-site.xml'
+    remote_src: yes

--- a/roles/ranger/kms/tasks/hdfs.yml
+++ b/roles/ranger/kms/tasks/hdfs.yml
@@ -4,6 +4,6 @@
 ---
 - name: Copy core-site.xml
   copy:
-    src: /etc/hadoop/conf/core-site.xml
+    src: '{{ hadoop_client_conf_dir }}/core-site.xml'
     dest: '{{ ranger_kms_conf_dir }}/conf/core-site.xml'
     remote_src: yes

--- a/roles/ranger/kms/tasks/hdfs.yml
+++ b/roles/ranger/kms/tasks/hdfs.yml
@@ -2,13 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-# Needed for HDFS path lookup in policy creation
-- name: Copy hdfs-site.xml
-  copy:
-    src: /etc/hadoop/conf/hdfs-site.xml
-    dest: '{{ ranger_kms_conf_dir }}/conf/hdfs-site.xml'
-    remote_src: yes
-
 - name: Copy core-site.xml
   copy:
     src: /etc/hadoop/conf/core-site.xml

--- a/roles/ranger/kms/tasks/init.yml
+++ b/roles/ranger/kms/tasks/init.yml
@@ -1,0 +1,32 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Create kms service
+  run_once: true
+  uri:
+    url: "{{ kms_install_properties.POLICY_MGR_URL }}/service/plugins/services"
+    method: POST
+    body:
+      name: "{{ kms_install_properties.REPOSITORY_NAME }}"
+      isEnabled: true
+      configs:
+        username: keyadmin
+        password: keyadmin
+        provider: "{{ ranger_kms_url }}"
+      type: kms
+    body_format: json
+    force_basic_auth: yes
+    user: admin
+    password: "{{ ranger_admin_password }}"
+    headers:
+      Content-Type: application/json
+    status_code: [200, 400]
+    validate_certs: no
+  register: reg_kms
+  changed_when: reg_kms.status == 200
+  failed_when: |
+    reg_kms is failed or
+    reg_kms.status == 400 and
+    (reg_kms.json.msgDesc is not defined or
+    'Duplicate service name' not in reg_kms.json.msgDesc)

--- a/roles/ranger/kms/tasks/install.yml
+++ b/roles/ranger/kms/tasks/install.yml
@@ -2,28 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-- include_role:
-    name: tosit.tdp.utils.group
-  vars:
-    group: "{{ hadoop_group }}"
-
-- include_role:
-    name: tosit.tdp.utils.user
-  vars:
-    user: "{{ ranger_kms_user }}"
-    group: "{{ hadoop_group }}"
-
-- name: Ensures {{ ranger_root_dir }} exists
-  file:
-    path: "{{ ranger_root_dir }}"
-    state: directory
-
-- name: Create Ranger KMS config directory
-  file:
-    path: '{{ ranger_kms_conf_dir }}'
-    state: directory
-    group: '{{ hadoop_group }}'
-    owner: '{{ ranger_kms_user }}'
+- import_role:
+    name: tosit.tdp.ranger.common
+    tasks_from: install
 
 - name: Upload {{ ranger_kms_dist_file }}
   copy:

--- a/roles/ranger/kms/tasks/install.yml
+++ b/roles/ranger/kms/tasks/install.yml
@@ -1,0 +1,76 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- include_role:
+    name: tosit.tdp.utils.group
+  vars:
+    group: "{{ hadoop_group }}"
+
+- include_role:
+    name: tosit.tdp.utils.user
+  vars:
+    user: "{{ ranger_kms_user }}"
+    group: "{{ hadoop_group }}"
+
+- name: Ensures {{ ranger_root_dir }} exists
+  file:
+    path: "{{ ranger_root_dir }}"
+    state: directory
+
+- name: Create Ranger KMS config directory
+  file:
+    path: '{{ ranger_kms_conf_dir }}'
+    state: directory
+    group: '{{ hadoop_group }}'
+    owner: '{{ ranger_kms_user }}'
+
+- name: Upload {{ ranger_kms_dist_file }}
+  copy:
+    src: "files/{{ ranger_kms_dist_file }}"
+    dest: /tmp
+  diff: no
+
+- name: Extract {{ ranger_kms_dist_file }}
+  unarchive:
+    src: "/tmp/{{ ranger_kms_dist_file }}"
+    dest: "{{ ranger_root_dir }}"
+    group: root
+    owner: root
+    remote_src: yes
+    creates: "{{ ranger_root_dir }}/{{ ranger_kms_release }}"
+
+- name: Create symbolic link to Ranger KMS installation
+  file:
+    src: "{{ ranger_root_dir }}/{{ ranger_kms_release }}"
+    dest: "{{ ranger_kms_install_dir }}"
+    state: link
+
+- name: Create directory for pid
+  file:
+    path: '{{ ranger_kms_pid_dir }}'
+    state: directory
+    group: '{{ hadoop_group }}'
+    owner: '{{ ranger_kms_user }}'
+
+- name: Template Ranger KMS tmpfiles.d
+  template:
+    src: tmpfiles-ranger-kms.conf.j2
+    dest: /etc/tmpfiles.d/ranger-kms.conf
+
+- name: Create log directory
+  file:
+    path: '{{ ranger_kms_log_dir }}'
+    state: directory
+    group: '{{ hadoop_group }}'
+    owner: '{{ ranger_kms_user }}'
+
+- name: Install jdbc connector
+  package:
+    name: "{{ ranger_jdbc_connector_package }}"
+    state: present
+
+- name: Template Ranger KMS service file
+  template:
+    src: ranger-kms.service.j2
+    dest: /usr/lib/systemd/system/ranger-kms.service

--- a/roles/ranger/kms/tasks/jmx-exporter.yml
+++ b/roles/ranger/kms/tasks/jmx-exporter.yml
@@ -1,0 +1,13 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Ensure configuration directory
+  file:
+    path: '{{ jmx_exporter_conf_dir }}'
+    state: directory
+
+- name: Render jmx-exporter config file jmx-exporter.yml
+  copy:
+    content: "{{ jmx_exporter | to_nice_yaml }}"
+    dest: "{{ jmx_exporter_conf_dir }}/ra.yml"

--- a/roles/ranger/kms/tasks/kerberos.yml
+++ b/roles/ranger/kms/tasks/kerberos.yml
@@ -1,0 +1,27 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: install
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: create_principal_keytab
+  vars:
+    principal: "keyadmin/{{ ansible_fqdn }}"
+    keytab: "keyadmin.service.keytab"
+    user: "{{ ranger_kms_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "600"
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: create_principal_keytab
+  vars:
+    principal: "HTTP/{{ ansible_fqdn }}"
+    keytab: "spnego.service.keytab"
+    user: "root"
+    group: "{{ hadoop_group }}"
+    mode: "640"

--- a/roles/ranger/kms/tasks/restart.yml
+++ b/roles/ranger/kms/tasks/restart.yml
@@ -1,0 +1,8 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Restart Ranger KMS
+  service:
+    name: ranger-kms
+    state: restarted

--- a/roles/ranger/kms/tasks/ssl-tls.yml
+++ b/roles/ranger/kms/tasks/ssl-tls.yml
@@ -1,0 +1,25 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- include_role:
+    name: tosit.tdp.utils.ssl_tls
+    tasks_from: create_keystore
+  vars:
+    keystore_location: "{{ ranger_keystore_location }}"
+    keystore_password: "{{ ranger_keystore_password }}"
+
+- include_role:
+    name: tosit.tdp.utils.ssl_tls
+    tasks_from: create_truststore
+  vars:
+    truststore_location: "{{ ranger_truststore_location }}"
+    truststore_password: "{{ ranger_truststore_password }}"
+
+- include_role:
+    name: tosit.tdp.utils.ssl_tls
+    tasks_from: verify_truststore
+  vars:
+    truststore_location: "/etc/pki/java/cacerts"
+    truststore_password: "changeit"
+    alias: "gateway-identity"

--- a/roles/ranger/kms/tasks/start.yml
+++ b/roles/ranger/kms/tasks/start.yml
@@ -1,0 +1,8 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Start Ranger KMS
+  service:
+    name: ranger-kms
+    state: started

--- a/roles/ranger/kms/tasks/stop.yml
+++ b/roles/ranger/kms/tasks/stop.yml
@@ -1,0 +1,8 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Stop Ranger KMS
+  service:
+    name: ranger-kms
+    state: stopped

--- a/roles/ranger/kms/templates
+++ b/roles/ranger/kms/templates
@@ -1,0 +1,1 @@
+../common/templates

--- a/roles/yarn/resourcemanager/tasks/ssl-tls.yml
+++ b/roles/yarn/resourcemanager/tasks/ssl-tls.yml
@@ -25,3 +25,11 @@
   vars:
     truststore_location: "{{ hadoop_truststore_location }}"
     truststore_password: "{{ hadoop_truststore_password }}"
+
+- include_role:
+    name: tosit.tdp.utils.ssl_tls
+    tasks_from: verify_truststore
+  vars:
+    truststore_location: "/etc/pki/java/cacerts"
+    truststore_password: "changeit"
+    alias: "root_ca"

--- a/tdp_lib_dag/ranger.yml
+++ b/tdp_lib_dag/ranger.yml
@@ -57,6 +57,7 @@
     - ranger_usersync_install
     - ranger_kerberos_install
     - ranger_ssl-tls_install
+    - ranger_kms_install
 
 - name: ranger_config
   noop: yes
@@ -65,6 +66,7 @@
     - ranger_admin_config
     - ranger_usersync_config
     - ranger_jmx-exporter_config
+    - ranger_kms_config
 
 - name: ranger_start
   noop: yes
@@ -72,9 +74,36 @@
     - ranger_config
     - ranger_admin_start
     - ranger_usersync_start
+    - ranger_kms_start
 
 - name: ranger_init
   noop: yes
   depends_on:
     - ranger_start
     - ranger_admin_init
+
+- name: ranger_kms_install
+  depends_on:
+    - ranger_kerberos_install
+    - ranger_ssl-tls_install
+
+- name: ranger_kms_config
+  depends_on:
+    - ranger_kms_install
+
+
+- name: ranger_kms_init
+  depends_on:
+    - ranger_admin_start
+    - ranger_usersync_start
+
+- name: ranger_kms_hdfs
+  depends_on:
+    - ranger_kms_config
+    - hadoop_install
+
+- name: ranger_kms_start
+  depends_on:
+    - ranger_kms_init
+    - ranger_kms_hdfs
+    - ranger_kms_config

--- a/tdp_lib_dag/ranger.yml
+++ b/tdp_lib_dag/ranger.yml
@@ -100,7 +100,7 @@
 - name: ranger_kms_hdfs
   depends_on:
     - ranger_kms_config
-    - hadoop_install
+    - hadoop_config
 
 - name: ranger_kms_start
   depends_on:

--- a/tdp_lib_dag/ranger.yml
+++ b/tdp_lib_dag/ranger.yml
@@ -50,6 +50,31 @@
   depends_on:
     - ranger_admin_start
 
+- name: ranger_kms_install
+  depends_on:
+    - ranger_kerberos_install
+    - ranger_ssl-tls_install
+
+- name: ranger_kms_config
+  depends_on:
+    - ranger_kms_install
+
+- name: ranger_kms_init
+  depends_on:
+    - ranger_admin_start
+    - ranger_usersync_start
+
+- name: ranger_kms_hdfs
+  depends_on:
+    - ranger_kms_config
+    - hadoop_config
+
+- name: ranger_kms_start
+  depends_on:
+    - ranger_kms_init
+    - ranger_kms_hdfs
+    - ranger_kms_config
+
 - name: ranger_install
   noop: yes
   depends_on:
@@ -81,29 +106,3 @@
   depends_on:
     - ranger_start
     - ranger_admin_init
-
-- name: ranger_kms_install
-  depends_on:
-    - ranger_kerberos_install
-    - ranger_ssl-tls_install
-
-- name: ranger_kms_config
-  depends_on:
-    - ranger_kms_install
-
-
-- name: ranger_kms_init
-  depends_on:
-    - ranger_admin_start
-    - ranger_usersync_start
-
-- name: ranger_kms_hdfs
-  depends_on:
-    - ranger_kms_config
-    - hadoop_config
-
-- name: ranger_kms_start
-  depends_on:
-    - ranger_kms_init
-    - ranger_kms_hdfs
-    - ranger_kms_config

--- a/tdp_vars_defaults/hadoop/hadoop.yml
+++ b/tdp_vars_defaults/hadoop/hadoop.yml
@@ -133,6 +133,7 @@ core_site:
   hadoop.ssl.server.conf: ssl-server.xml
   hadoop.ssl.client.conf: ssl-client.xml
   fs.trash.checkpoint.interval: 360
+  hadoop.security.key.provider.path: "{% if 'ranger_kms' in groups and groups['ranger_kms'] %}{{ ranger_kms_url }}{% else %}NONE{% endif %}"
 
 # mapred-site.xml
 mapred_site:
@@ -175,3 +176,12 @@ jmx_exporter:
   password: "{{ jmxremote_password }}"
   lowercaseOutputName: false
   lowercaseOutputLabelNames: false
+
+# Ranger KMS url 
+ranger_kms_url: "kms://{{ ranger_kms_hosts }}:9393/kms"
+ranger_kms_hosts: |-
+    {{ groups['ranger_kms'] | 
+      map('tosit.tdp.access_fqdn', hostvars) |
+      map('regex_replace', '^', 'https@') |
+      list |
+      join(';') }}

--- a/tdp_vars_defaults/hdfs/hdfs.yml
+++ b/tdp_vars_defaults/hdfs/hdfs.yml
@@ -53,6 +53,7 @@ hdfs_site:
   dfs.datanode.data.dir: "/data/hdfs/dn"
   dfs.datanode.kerberos.principal: dn/_HOST@{{ realm }}
   dfs.datanode.keytab.file: /etc/security/keytabs/dn.service.keytab
+  dfs.encryption.key.provider.uri: "{% if 'ranger_kms' in groups and groups['ranger_kms'] %}{{ ranger_kms_url }}{% else %}NONE{% endif %}"
 
 namenode_kerberos_principal: "nn/{{ ansible_fqdn }}@{{ realm }}"
 

--- a/tdp_vars_defaults/hdfs/hdfs.yml
+++ b/tdp_vars_defaults/hdfs/hdfs.yml
@@ -53,7 +53,7 @@ hdfs_site:
   dfs.datanode.data.dir: "/data/hdfs/dn"
   dfs.datanode.kerberos.principal: dn/_HOST@{{ realm }}
   dfs.datanode.keytab.file: /etc/security/keytabs/dn.service.keytab
-  dfs.encryption.key.provider.uri: "{% if 'ranger_kms' in groups and groups['ranger_kms'] %}{{ ranger_kms_url }}{% else %}NONE{% endif %}"
+  dfs.encryption.key.provider.uri: "{% if 'ranger_kms' in groups and groups['ranger_kms'] %}{{ ranger_kms_hdfs_url }}{% else %}NONE{% endif %}"
 
 namenode_kerberos_principal: "nn/{{ ansible_fqdn }}@{{ realm }}"
 
@@ -72,3 +72,11 @@ hdfs_nn_restart: "no"
 hdfs_dn_restart: "no"
 hdfs_jn_restart: "no"
 hdfs_zkfc_restart: "no"
+
+# Ranger KMS url 
+ranger_kms_hdfs_url: "kms://https@{{ ranger_kms_hdfs_hosts }}:9393/kms"
+ranger_kms_hdfs_hosts: |-
+    {{ groups['ranger_kms'] | 
+      map('tosit.tdp.access_fqdn', hostvars) |
+      list |
+      join(';') }}

--- a/tdp_vars_defaults/ranger/ranger.yml
+++ b/tdp_vars_defaults/ranger/ranger.yml
@@ -18,8 +18,8 @@ hadoop_group: hadoop
 # Ranger installation directory
 ranger_root_dir: /opt/tdp
 ranger_install_dir: "{{ ranger_root_dir }}/ranger"
-ranger_usersync_install_dir: "/opt/tdp/ranger-usersync"
-ranger_kms_install_dir: "/opt/tdp/ranger-kms"
+ranger_usersync_install_dir: "{{ ranger_root_dir }}/ranger-usersync"
+ranger_kms_install_dir: "{{ ranger_root_dir }}/ranger-kms"
 
 # Ranger configuration directories
 ranger_conf_dir: /etc/ranger

--- a/tdp_vars_defaults/ranger/ranger.yml
+++ b/tdp_vars_defaults/ranger/ranger.yml
@@ -138,6 +138,9 @@ jmx_common_opts: "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxre
 jmx_exporter_ra_opts: "{% if 'exporter_jmx' in groups and groups['exporter_jmx'] %}-javaagent:{{ jmx_exporter_install_file }}=18117:{{ jmx_exporter_conf_dir }}/ra.yml{% else %}{% endif %}"
 jmx_exporter_ru_opts: "{% if 'exporter_jmx' in groups and groups['exporter_jmx'] %}-javaagent:{{ jmx_exporter_install_file }}=18118:{{ jmx_exporter_conf_dir }}/ru.yml{% else %}{% endif %}"
 
+# kms jmx-exporter
+jmx_kms_exporter_ra_opts: "{% if 'exporter_jmx' in groups and groups['exporter_jmx'] %}-javaagent:{{ jmx_exporter_install_file }}=18119:{{ jmx_exporter_conf_dir }}/ra.yml{% else %}{% endif %}"
+jmx_kms_exporter_ru_opts: "{% if 'exporter_jmx' in groups and groups['exporter_jmx'] %}-javaagent:{{ jmx_exporter_install_file }}=18120:{{ jmx_exporter_conf_dir }}/ru.yml{% else %}{% endif %}"
 
 jmxremote_username: jmxuser
 jmxremote_password: Tdpjmx123,

--- a/tdp_vars_defaults/ranger/ranger.yml
+++ b/tdp_vars_defaults/ranger/ranger.yml
@@ -7,27 +7,34 @@ ranger_release: ranger-2.0.1-TDP-0.1.0-SNAPSHOT-admin
 ranger_dist_file: "{{ ranger_release }}.tar.gz"
 ranger_usersync_release: ranger-2.0.1-TDP-0.1.0-SNAPSHOT-usersync
 ranger_usersync_dist_file: "{{ ranger_usersync_release }}.tar.gz"
+ranger_kms_release: ranger-2.0.1-TDP-0.1.0-SNAPSHOT-kms
+ranger_kms_dist_file: "{{ ranger_kms_release }}.tar.gz"
 
 # Ranger users and group
 ranger_user: ranger
+ranger_kms_user: keyadmin
 hadoop_group: hadoop
 
 # Ranger installation directory
 ranger_root_dir: /opt/tdp
 ranger_install_dir: "{{ ranger_root_dir }}/ranger"
 ranger_usersync_install_dir: "/opt/tdp/ranger-usersync"
+ranger_kms_install_dir: "/opt/tdp/ranger-kms"
 
 # Ranger configuration directories
 ranger_conf_dir: /etc/ranger
 ranger_adm_conf_dir: "{{ ranger_conf_dir }}/conf.adm"
+ranger_kms_conf_dir: "/etc/kms"
 
 # Ranger pid directories
 ranger_pid_dir: /var/run/ranger
 ranger_usersync_pid_dir: /var/run/ranger-usersync
+ranger_kms_pid_dir: /var/run/ranger-kms
 
 # Ranger logging directory
 ranger_log_dir: /var/log/ranger
 ranger_usersync_log_dir: /var/log/ranger-usersync
+ranger_kms_log_dir: /var/log/ranger-kms
 
 # Ranger passwords
 ranger_admin_password: RangerAdmin123
@@ -57,6 +64,20 @@ install_properties:
   audit_store: "{% if 'ranger_solr' in groups and groups['ranger_solr'] %}solr{% else %}db{% endif %}" 
   audit_solr_urls: "{% if 'ranger_solr' in groups and groups['ranger_solr'] %}http://{{ groups['ranger_solr'][0] | tosit.tdp.access_fqdn(hostvars) }}:8983/solr/ranger_audits{% else %}{% endif %}"
 
+# Ranger KMS install.properties
+kms_install_properties:
+  setup_mode: SeparateDBA
+  DB_FLAVOR: MYSQL
+  SQL_CONNECTOR_JAR: /usr/share/java/mysql-connector-java.jar
+  db_host: localhost
+  db_name: rangerkms
+  db_user: rangerkms
+  db_password: rangerkms
+  POLICY_MGR_URL: "https://{{ groups['ranger_admin'][0] | tosit.tdp.access_fqdn(hostvars) }}:6182"
+  REPOSITORY_NAME: kms-tdp
+  XAAUDIT_SOLR_ENABLE: "{% if 'ranger_solr' in groups and groups['ranger_solr'] %}true{% else %}false{% endif %}"
+  XAAUDIT_SOLR_URL: "{% if 'ranger_solr' in groups and groups['ranger_solr'] %}http://{{ groups['ranger_solr'][0] | tosit.tdp.access_fqdn(hostvars) }}:8983/solr/ranger_audits{% else %}NONE{% endif %}"  
+
 # Ranger Usersync install.properties
 usersync_install_properties:
   POLICY_MGR_URL: "https://{{ groups['ranger_admin'][0] | tosit.tdp.access_fqdn(hostvars) }}:6182"
@@ -72,6 +93,8 @@ usersync_install_properties:
 # Service restart policies
 ranger_admin_restart: "no"
 ranger_usync_restart: "no"
+ranger_kms_restart: "no"
+
 
 # Solr version
 solr_release: solr-7.7.3


### PR DESCRIPTION
<!--  Thank you for sending a pull request! Please make sure:

1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes:
<!--
Example: "Fixes #(issue number)" or "Fixes (link of issue)".
-->
Fixes #354 

This PR adds Ranger KMS service to tdp collection with:
- ranger admin integration for (1) keys and (2) policies management 
- enable ssl for kms
- add ssl/tls adequate integration for knox/swebhdfs support 
- full kerberos support 
- solr audit integration 
- jmx integration
- dag integration
- hive integration 
- spark integration
- knox integration
- HA support

**Requirements** :
- create a database for kms and setup its config in the `ranger.yml` vars

**For test** :
 - login to ranger amin with keyadmin creds, (default : keyadmin/RangerKeyAdmin123)
 - create a new key via ranger admin : Encryption -> select service -> kms-tdp -> add new key 
 - add a kms policy for you user via ranger admin : access manager -> kms-tdp
 - connect to edge
 - generate a kerberos token : `kinit`
 - try to list all keys with an authorized user: `hadoop key list`
 - create a new hdfs dir : `hdfs dfs -mkdir /secure`
 - add hdfs ranger policy to this path
 - create an encrypted zone with the generated key: `hdfs crypto -createZone  -keyName <your_generated_key> -path /secure`
 - try to put a file via `hdfs dfs -put /etc/hosts hdfs://mycluster/secrue` or `hdfs dfs -put /etc/hosts swebhdfs://mycluster/secrue`
 - try to read it with different users via the same commands (`hdfs` or `swebhdfs`) or `knox`

#### Additional comments:
<!--
Example: `"I was not sure if it is the right way to do but..."
-->

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to [TOSIT](https://www.tosit.io/),
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.

