### PR TITLE
Optional principals and keytabs creation and custom headless principals

### DIFF
--- a/roles/hadoop/client/tasks/kerberos.yml
+++ b/roles/hadoop/client/tasks/kerberos.yml
@@ -10,7 +10,7 @@
     name: tosit.tdp.utils.kerberos
     tasks_from: create_headless_principal_keytab
   vars:
-    principal: "mapred"
+    principal: "{{ mapred_headless_principal }}"
     keytab: "mapred.headless.keytab"
     user: "{{ mapred_user }}"
     group: "{{ hadoop_group }}"
@@ -21,7 +21,7 @@
     name: tosit.tdp.utils.kerberos
     tasks_from: check_secure_keytab
   vars:
-    principal: "mapred"
+    principal: "{{ mapred_headless_principal }}"
     keytab: "mapred.headless.keytab"
     user: "{{ mapred_user }}"
     group: "{{ hadoop_group }}"

--- a/roles/hadoop/client/tasks/kerberos.yml
+++ b/roles/hadoop/client/tasks/kerberos.yml
@@ -15,3 +15,4 @@
     user: "{{ mapred_user }}"
     group: "{{ hadoop_group }}"
     mode: "600"
+  when: krb_create_principals_keytabs

--- a/roles/hadoop/client/tasks/kerberos.yml
+++ b/roles/hadoop/client/tasks/kerberos.yml
@@ -16,3 +16,14 @@
     group: "{{ hadoop_group }}"
     mode: "600"
   when: krb_create_principals_keytabs
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: check_secure_keytab
+  vars:
+    principal: "mapred"
+    keytab: "mapred.headless.keytab"
+    user: "{{ mapred_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "600"
+  when: not krb_create_principals_keytabs

--- a/roles/hbase/client/tasks/kerberos.yml
+++ b/roles/hbase/client/tasks/kerberos.yml
@@ -15,7 +15,7 @@
     name: tosit.tdp.utils.kerberos
     tasks_from: create_headless_principal_keytab
   vars:
-    principal: "hbase"
+    principal: "{{ hbase_headless_principal }}"
     keytab: "hbase.headless.keytab"
     user: "{{ hbase_user }}"
     group: "{{ hadoop_group }}"
@@ -26,7 +26,7 @@
     name: tosit.tdp.utils.kerberos
     tasks_from: check_secure_keytab
   vars:
-    principal: "hbase"
+    principal: "{{ hbase_headless_principal }}"
     keytab: "hbase.headless.keytab"
     user: "{{ hbase_user }}"
     group: "{{ hadoop_group }}"

--- a/roles/hbase/client/tasks/kerberos.yml
+++ b/roles/hbase/client/tasks/kerberos.yml
@@ -21,3 +21,14 @@
     group: "{{ hadoop_group }}"
     mode: "600"
   when: krb_create_principals_keytabs
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: check_secure_keytab
+  vars:
+    principal: "hbase"
+    keytab: "hbase.headless.keytab"
+    user: "{{ hbase_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "600"
+  when: not krb_create_principals_keytabs

--- a/roles/hbase/client/tasks/kerberos.yml
+++ b/roles/hbase/client/tasks/kerberos.yml
@@ -9,7 +9,7 @@
 - name: Template krb5 JAAS
   template:
     src: hbase/krb5JAASClient.conf.j2
-    dest: '{{ hbase_client_conf_dir }}/krb5JAASClient.conf'
+    dest: "{{ hbase_client_conf_dir }}/krb5JAASClient.conf"
 
 - import_role:
     name: tosit.tdp.utils.kerberos
@@ -20,3 +20,4 @@
     user: "{{ hbase_user }}"
     group: "{{ hadoop_group }}"
     mode: "600"
+  when: krb_create_principals_keytabs

--- a/roles/hbase/master/tasks/hdfs_init.yml
+++ b/roles/hbase/master/tasks/hdfs_init.yml
@@ -12,7 +12,7 @@
     group: "{{ item.group | default(omit) }}"
     mode: "{{ item.mode | default(omit) }}"
     kerberos: yes
-    krb_principal: "hdfs@{{ realm }}"
+    krb_principal: "{{ hdfs_headless_principal }}@{{ realm }}"
     krb_keytab: /etc/security/keytabs/hdfs.headless.keytab
   become: yes
   become_user: "{{ hdfs_user }}"
@@ -21,19 +21,19 @@
       state: directory
       owner: "{{ hbase_user }}"
       group: "{{ hadoop_group }}"
-      mode: '775'
+      mode: "775"
     - path: /ranger/audit/hbase
       state: directory
       owner: "{{ hbase_user }}"
       group: "{{ hbase_user }}"
-      mode: '700'
+      mode: "700"
     - path: /ranger/audit/hbaseMaster
       state: directory
       owner: "{{ hbase_user }}"
       group: "{{ hbase_user }}"
-      mode: '700'
+      mode: "700"
     - path: /ranger/audit/hbaseRegional
       state: directory
       owner: "{{ hbase_user }}"
       group: "{{ hbase_user }}"
-      mode: '700'
+      mode: "700"

--- a/roles/hbase/master/tasks/kerberos.yml
+++ b/roles/hbase/master/tasks/kerberos.yml
@@ -13,7 +13,7 @@
 - name: Template krb5 JAAS
   template:
     src: hbase/krb5JAASServer.conf.j2
-    dest: '{{ hbase_master_conf_dir }}/krb5JAASServer.conf'
+    dest: "{{ hbase_master_conf_dir }}/krb5JAASServer.conf"
   vars:
     hbase_keytab_file: "{{ hbase_site['hbase.master.keytab.file'] }}"
     hbase_principal: "{{ hbase_master_kerberos_principal }}"
@@ -27,3 +27,4 @@
     user: "{{ hbase_user }}"
     group: "{{ hadoop_group }}"
     mode: "600"
+  when: krb_create_principals_keytabs

--- a/roles/hbase/master/tasks/kerberos.yml
+++ b/roles/hbase/master/tasks/kerberos.yml
@@ -28,3 +28,14 @@
     group: "{{ hadoop_group }}"
     mode: "600"
   when: krb_create_principals_keytabs
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: check_secure_keytab
+  vars:
+    principal: "hbase/{{ ansible_fqdn }}"
+    keytab: "hbase.service.keytab"
+    user: "{{ hbase_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "600"
+  when: not krb_create_principals_keytabs

--- a/roles/hbase/phoenix/queryserver/daemon/tasks/kerberos.yml
+++ b/roles/hbase/phoenix/queryserver/daemon/tasks/kerberos.yml
@@ -14,6 +14,7 @@
     keytab: "phoenixqueryserver.service.keytab"
     user: "{{ phoenix_queryserver_user }}"
     group: "{{ hadoop_group }}"
+  when: krb_create_principals_keytabs
 
 - import_role:
     name: tosit.tdp.utils.kerberos
@@ -24,3 +25,4 @@
     user: "root"
     group: "{{ hadoop_group }}"
     mode: "640"
+  when: krb_create_principals_keytabs

--- a/roles/hbase/phoenix/queryserver/daemon/tasks/kerberos.yml
+++ b/roles/hbase/phoenix/queryserver/daemon/tasks/kerberos.yml
@@ -6,23 +6,44 @@
     name: tosit.tdp.utils.kerberos
     tasks_from: install
 
-- import_role:
-    name: tosit.tdp.utils.kerberos
-    tasks_from: create_principal_keytab
-  vars:
-    principal: "phoenixqueryserver/{{ ansible_fqdn }}"
-    keytab: "phoenixqueryserver.service.keytab"
-    user: "{{ phoenix_queryserver_user }}"
-    group: "{{ hadoop_group }}"
+- block:
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: create_principal_keytab
+      vars:
+        principal: "phoenixqueryserver/{{ ansible_fqdn }}"
+        keytab: "phoenixqueryserver.service.keytab"
+        user: "{{ phoenix_queryserver_user }}"
+        group: "{{ hadoop_group }}"
+
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: create_principal_keytab
+      vars:
+        principal: "HTTP/{{ ansible_fqdn }}"
+        keytab: "spnego.service.keytab"
+        user: "root"
+        group: "{{ hadoop_group }}"
+        mode: "640"
   when: krb_create_principals_keytabs
 
-- import_role:
-    name: tosit.tdp.utils.kerberos
-    tasks_from: create_principal_keytab
-  vars:
-    principal: "HTTP/{{ ansible_fqdn }}"
-    keytab: "spnego.service.keytab"
-    user: "root"
-    group: "{{ hadoop_group }}"
-    mode: "640"
-  when: krb_create_principals_keytabs
+- block:
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: check_secure_keytab
+      vars:
+        principal: "phoenixqueryserver/{{ ansible_fqdn }}"
+        keytab: "phoenixqueryserver.service.keytab"
+        user: "{{ phoenix_queryserver_user }}"
+        group: "{{ hadoop_group }}"
+
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: check_secure_keytab
+      vars:
+        principal: "HTTP/{{ ansible_fqdn }}"
+        keytab: "spnego.service.keytab"
+        user: "root"
+        group: "{{ hadoop_group }}"
+        mode: "640"
+  when: not krb_create_principals_keytabs

--- a/roles/hbase/regionserver/tasks/kerberos.yml
+++ b/roles/hbase/regionserver/tasks/kerberos.yml
@@ -28,3 +28,14 @@
     group: "{{ hadoop_group }}"
     mode: "600"
   when: krb_create_principals_keytabs
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: check_secure_keytab
+  vars:
+    principal: "hbase/{{ ansible_fqdn }}"
+    keytab: "hbase.service.keytab"
+    user: "{{ hbase_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "600"
+  when: not krb_create_principals_keytabs

--- a/roles/hbase/regionserver/tasks/kerberos.yml
+++ b/roles/hbase/regionserver/tasks/kerberos.yml
@@ -13,7 +13,7 @@
 - name: Template krb5 JAAS
   template:
     src: hbase/krb5JAASServer.conf.j2
-    dest: '{{ hbase_rs_conf_dir }}/krb5JAASServer.conf'
+    dest: "{{ hbase_rs_conf_dir }}/krb5JAASServer.conf"
   vars:
     hbase_keytab_file: "{{ hbase_site['hbase.regionserver.keytab.file'] }}"
     hbase_principal: "{{ hbase_regionserver_kerberos_principal }}"
@@ -27,3 +27,4 @@
     user: "{{ hbase_user }}"
     group: "{{ hadoop_group }}"
     mode: "600"
+  when: krb_create_principals_keytabs

--- a/roles/hbase/rest/tasks/kerberos.yml
+++ b/roles/hbase/rest/tasks/kerberos.yml
@@ -13,7 +13,7 @@
 - name: Template krb5 JAAS
   template:
     src: hbase/krb5JAASServer.conf.j2
-    dest: '{{ hbase_rest_conf_dir }}/krb5JAASServer.conf'
+    dest: "{{ hbase_rest_conf_dir }}/krb5JAASServer.conf"
   vars:
     hbase_keytab_file: "{{ hbase_site['hbase.rest.keytab.file'] }}"
     hbase_principal: "{{ hbase_rest_kerberos_principal }}"
@@ -27,6 +27,7 @@
     user: "{{ hbase_user }}"
     group: "{{ hadoop_group }}"
     mode: "600"
+  when: krb_create_principals_keytabs
 
 - import_role:
     name: tosit.tdp.utils.kerberos
@@ -37,3 +38,4 @@
     user: "root"
     group: "{{ hadoop_group }}"
     mode: "640"
+  when: krb_create_principals_keytabs

--- a/roles/hbase/rest/tasks/kerberos.yml
+++ b/roles/hbase/rest/tasks/kerberos.yml
@@ -18,24 +18,46 @@
     hbase_keytab_file: "{{ hbase_site['hbase.rest.keytab.file'] }}"
     hbase_principal: "{{ hbase_rest_kerberos_principal }}"
 
-- import_role:
-    name: tosit.tdp.utils.kerberos
-    tasks_from: create_principal_keytab
-  vars:
-    principal: "hbase/{{ ansible_fqdn }}"
-    keytab: "hbase.service.keytab"
-    user: "{{ hbase_user }}"
-    group: "{{ hadoop_group }}"
-    mode: "600"
+- block:
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: create_principal_keytab
+      vars:
+        principal: "hbase/{{ ansible_fqdn }}"
+        keytab: "hbase.service.keytab"
+        user: "{{ hbase_user }}"
+        group: "{{ hadoop_group }}"
+        mode: "600"
+
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: create_principal_keytab
+      vars:
+        principal: "HTTP/{{ ansible_fqdn }}"
+        keytab: "spnego.service.keytab"
+        user: "root"
+        group: "{{ hadoop_group }}"
+        mode: "640"
   when: krb_create_principals_keytabs
 
-- import_role:
-    name: tosit.tdp.utils.kerberos
-    tasks_from: create_principal_keytab
-  vars:
-    principal: "HTTP/{{ ansible_fqdn }}"
-    keytab: "spnego.service.keytab"
-    user: "root"
-    group: "{{ hadoop_group }}"
-    mode: "640"
-  when: krb_create_principals_keytabs
+- block:
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: check_secure_keytab
+      vars:
+        principal: "hbase/{{ ansible_fqdn }}"
+        keytab: "hbase.service.keytab"
+        user: "{{ hbase_user }}"
+        group: "{{ hadoop_group }}"
+        mode: "600"
+
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: check_secure_keytab
+      vars:
+        principal: "HTTP/{{ ansible_fqdn }}"
+        keytab: "spnego.service.keytab"
+        user: "root"
+        group: "{{ hadoop_group }}"
+        mode: "640"
+  when: not krb_create_principals_keytabs

--- a/roles/hdfs/client/tasks/kerberos.yml
+++ b/roles/hdfs/client/tasks/kerberos.yml
@@ -16,3 +16,14 @@
     group: "{{ hadoop_group }}"
     mode: "600"
   when: krb_create_principals_keytabs
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: check_secure_keytab
+  vars:
+    principal: "hdfs"
+    keytab: "hdfs.headless.keytab"
+    user: "{{ hdfs_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "600"
+  when: not krb_create_principals_keytabs

--- a/roles/hdfs/client/tasks/kerberos.yml
+++ b/roles/hdfs/client/tasks/kerberos.yml
@@ -15,3 +15,4 @@
     user: "{{ hdfs_user }}"
     group: "{{ hadoop_group }}"
     mode: "600"
+  when: krb_create_principals_keytabs

--- a/roles/hdfs/client/tasks/kerberos.yml
+++ b/roles/hdfs/client/tasks/kerberos.yml
@@ -10,7 +10,7 @@
     name: tosit.tdp.utils.kerberos
     tasks_from: create_headless_principal_keytab
   vars:
-    principal: "hdfs"
+    principal: "{{ hdfs_headless_principal }}"
     keytab: "hdfs.headless.keytab"
     user: "{{ hdfs_user }}"
     group: "{{ hadoop_group }}"
@@ -21,7 +21,7 @@
     name: tosit.tdp.utils.kerberos
     tasks_from: check_secure_keytab
   vars:
-    principal: "hdfs"
+    principal: "{{ hdfs_headless_principal }}"
     keytab: "hdfs.headless.keytab"
     user: "{{ hdfs_user }}"
     group: "{{ hadoop_group }}"

--- a/roles/hdfs/datanode/tasks/kerberos.yml
+++ b/roles/hdfs/datanode/tasks/kerberos.yml
@@ -19,6 +19,7 @@
     user: "{{ hdfs_user }}"
     group: "{{ hadoop_group }}"
     mode: "600"
+  when: krb_create_principals_keytabs
 
 - import_role:
     name: tosit.tdp.utils.kerberos
@@ -29,3 +30,4 @@
     user: "root"
     group: "{{ hadoop_group }}"
     mode: "640"
+  when: krb_create_principals_keytabs

--- a/roles/hdfs/datanode/tasks/kerberos.yml
+++ b/roles/hdfs/datanode/tasks/kerberos.yml
@@ -10,24 +10,46 @@
     name: tosit.tdp.hadoop.common
     tasks_from: kerberos
 
-- import_role:
-    name: tosit.tdp.utils.kerberos
-    tasks_from: create_principal_keytab
-  vars:
-    principal: "dn/{{ ansible_fqdn }}"
-    keytab: "dn.service.keytab"
-    user: "{{ hdfs_user }}"
-    group: "{{ hadoop_group }}"
-    mode: "600"
+- block:
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: create_principal_keytab
+      vars:
+        principal: "dn/{{ ansible_fqdn }}"
+        keytab: "dn.service.keytab"
+        user: "{{ hdfs_user }}"
+        group: "{{ hadoop_group }}"
+        mode: "600"
+
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: create_principal_keytab
+      vars:
+        principal: "HTTP/{{ ansible_fqdn }}"
+        keytab: "spnego.service.keytab"
+        user: "root"
+        group: "{{ hadoop_group }}"
+        mode: "640"
   when: krb_create_principals_keytabs
 
-- import_role:
-    name: tosit.tdp.utils.kerberos
-    tasks_from: create_principal_keytab
-  vars:
-    principal: "HTTP/{{ ansible_fqdn }}"
-    keytab: "spnego.service.keytab"
-    user: "root"
-    group: "{{ hadoop_group }}"
-    mode: "640"
-  when: krb_create_principals_keytabs
+- block:
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: check_secure_keytab
+      vars:
+        principal: "dn/{{ ansible_fqdn }}"
+        keytab: "dn.service.keytab"
+        user: "{{ hdfs_user }}"
+        group: "{{ hadoop_group }}"
+        mode: "600"
+
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: check_secure_keytab
+      vars:
+        principal: "HTTP/{{ ansible_fqdn }}"
+        keytab: "spnego.service.keytab"
+        user: "root"
+        group: "{{ hadoop_group }}"
+        mode: "640"
+  when: not krb_create_principals_keytabs

--- a/roles/hdfs/journalnode/tasks/kerberos.yml
+++ b/roles/hdfs/journalnode/tasks/kerberos.yml
@@ -6,24 +6,46 @@
     name: tosit.tdp.utils.kerberos
     tasks_from: install
 
-- import_role:
-    name: tosit.tdp.utils.kerberos
-    tasks_from: create_principal_keytab
-  vars:
-    principal: "jn/{{ ansible_fqdn }}"
-    keytab: "jn.service.keytab"
-    user: "{{ hdfs_user }}"
-    group: "{{ hadoop_group }}"
-    mode: "600"
+- block:
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: create_principal_keytab
+      vars:
+        principal: "jn/{{ ansible_fqdn }}"
+        keytab: "jn.service.keytab"
+        user: "{{ hdfs_user }}"
+        group: "{{ hadoop_group }}"
+        mode: "600"
+
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: create_principal_keytab
+      vars:
+        principal: "HTTP/{{ ansible_fqdn }}"
+        keytab: "spnego.service.keytab"
+        user: "root"
+        group: "{{ hadoop_group }}"
+        mode: "640"
   when: krb_create_principals_keytabs
 
-- import_role:
-    name: tosit.tdp.utils.kerberos
-    tasks_from: create_principal_keytab
-  vars:
-    principal: "HTTP/{{ ansible_fqdn }}"
-    keytab: "spnego.service.keytab"
-    user: "root"
-    group: "{{ hadoop_group }}"
-    mode: "640"
-  when: krb_create_principals_keytabs
+- block:
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: check_secure_keytab
+      vars:
+        principal: "jn/{{ ansible_fqdn }}"
+        keytab: "jn.service.keytab"
+        user: "{{ hdfs_user }}"
+        group: "{{ hadoop_group }}"
+        mode: "600"
+
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: check_secure_keytab
+      vars:
+        principal: "HTTP/{{ ansible_fqdn }}"
+        keytab: "spnego.service.keytab"
+        user: "root"
+        group: "{{ hadoop_group }}"
+        mode: "640"
+  when: not krb_create_principals_keytabs

--- a/roles/hdfs/journalnode/tasks/kerberos.yml
+++ b/roles/hdfs/journalnode/tasks/kerberos.yml
@@ -15,6 +15,7 @@
     user: "{{ hdfs_user }}"
     group: "{{ hadoop_group }}"
     mode: "600"
+  when: krb_create_principals_keytabs
 
 - import_role:
     name: tosit.tdp.utils.kerberos
@@ -25,3 +26,4 @@
     user: "root"
     group: "{{ hadoop_group }}"
     mode: "640"
+  when: krb_create_principals_keytabs

--- a/roles/hdfs/namenode/tasks/kerberos.yml
+++ b/roles/hdfs/namenode/tasks/kerberos.yml
@@ -15,24 +15,46 @@
     src: krb5JAASnn.conf.j2
     dest: "{{ hadoop_nn_conf_dir }}/krb5JAASnn.conf"
 
-- import_role:
-    name: tosit.tdp.utils.kerberos
-    tasks_from: create_principal_keytab
-  vars:
-    principal: "nn/{{ ansible_fqdn }}"
-    keytab: "nn.service.keytab"
-    user: "{{ hdfs_user }}"
-    group: "{{ hadoop_group }}"
-    mode: "600"
+- block:
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: create_principal_keytab
+      vars:
+        principal: "nn/{{ ansible_fqdn }}"
+        keytab: "nn.service.keytab"
+        user: "{{ hdfs_user }}"
+        group: "{{ hadoop_group }}"
+        mode: "600"
+
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: create_principal_keytab
+      vars:
+        principal: "HTTP/{{ ansible_fqdn }}"
+        keytab: "spnego.service.keytab"
+        user: "root"
+        group: "{{ hadoop_group }}"
+        mode: "640"
   when: krb_create_principals_keytabs
 
-- import_role:
-    name: tosit.tdp.utils.kerberos
-    tasks_from: create_principal_keytab
-  vars:
-    principal: "HTTP/{{ ansible_fqdn }}"
-    keytab: "spnego.service.keytab"
-    user: "root"
-    group: "{{ hadoop_group }}"
-    mode: "640"
-  when: krb_create_principals_keytabs
+- block:
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: check_secure_keytab
+      vars:
+        principal: "nn/{{ ansible_fqdn }}"
+        keytab: "nn.service.keytab"
+        user: "{{ hdfs_user }}"
+        group: "{{ hadoop_group }}"
+        mode: "600"
+
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: check_secure_keytab
+      vars:
+        principal: "HTTP/{{ ansible_fqdn }}"
+        keytab: "spnego.service.keytab"
+        user: "root"
+        group: "{{ hadoop_group }}"
+        mode: "640"
+  when: not krb_create_principals_keytabs

--- a/roles/hdfs/namenode/tasks/kerberos.yml
+++ b/roles/hdfs/namenode/tasks/kerberos.yml
@@ -13,7 +13,7 @@
 - name: Template krb5 jaas
   template:
     src: krb5JAASnn.conf.j2
-    dest: '{{ hadoop_nn_conf_dir }}/krb5JAASnn.conf'
+    dest: "{{ hadoop_nn_conf_dir }}/krb5JAASnn.conf"
 
 - import_role:
     name: tosit.tdp.utils.kerberos
@@ -24,6 +24,7 @@
     user: "{{ hdfs_user }}"
     group: "{{ hadoop_group }}"
     mode: "600"
+  when: krb_create_principals_keytabs
 
 - import_role:
     name: tosit.tdp.utils.kerberos
@@ -34,3 +35,4 @@
     user: "root"
     group: "{{ hadoop_group }}"
     mode: "640"
+  when: krb_create_principals_keytabs

--- a/roles/hive/client/tasks/kerberos.yml
+++ b/roles/hive/client/tasks/kerberos.yml
@@ -16,3 +16,14 @@
     group: "{{ hadoop_group }}"
     mode: "600"
   when: krb_create_principals_keytabs
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: check_secure_keytab
+  vars:
+    principal: "hive"
+    keytab: "hive.headless.keytab"
+    user: "{{ hive_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "600"
+  when: not krb_create_principals_keytabs

--- a/roles/hive/client/tasks/kerberos.yml
+++ b/roles/hive/client/tasks/kerberos.yml
@@ -15,3 +15,4 @@
     user: "{{ hive_user }}"
     group: "{{ hadoop_group }}"
     mode: "600"
+  when: krb_create_principals_keytabs

--- a/roles/hive/client/tasks/kerberos.yml
+++ b/roles/hive/client/tasks/kerberos.yml
@@ -10,7 +10,7 @@
     name: tosit.tdp.utils.kerberos
     tasks_from: create_headless_principal_keytab
   vars:
-    principal: "hive"
+    principal: "{{ hive_headless_principal }}"
     keytab: "hive.headless.keytab"
     user: "{{ hive_user }}"
     group: "{{ hadoop_group }}"
@@ -21,7 +21,7 @@
     name: tosit.tdp.utils.kerberos
     tasks_from: check_secure_keytab
   vars:
-    principal: "hive"
+    principal: "{{ hive_headless_principal }}"
     keytab: "hive.headless.keytab"
     user: "{{ hive_user }}"
     group: "{{ hadoop_group }}"

--- a/roles/hive/common/tasks/hdfs_init.yml
+++ b/roles/hive/common/tasks/hdfs_init.yml
@@ -12,7 +12,7 @@
     group: "{{ item.group | default(omit) }}"
     mode: "{{ item.mode | default(omit) }}"
     kerberos: yes
-    krb_principal: "hdfs@{{ realm }}"
+    krb_principal: "{{ hdfs_headless_principal }}@{{ realm }}"
     krb_keytab: /etc/security/keytabs/hdfs.headless.keytab
   become: yes
   become_user: "{{ hdfs_user }}"
@@ -47,7 +47,7 @@
 
 - name: Kinit for hdfs
   run_once: yes
-  command: "kinit -kt /etc/security/keytabs/hdfs.headless.keytab hdfs@{{ realm }}"
+  command: "kinit -kt /etc/security/keytabs/hdfs.headless.keytab {{ hdfs_headless_principal }}@{{ realm }}"
   become: yes
   become_user: "{{ hdfs_user }}"
   changed_when: no

--- a/roles/hive/hiveserver2/tasks/kerberos.yml
+++ b/roles/hive/hiveserver2/tasks/kerberos.yml
@@ -15,6 +15,7 @@
     user: "{{ hive_user }}"
     group: "{{ hadoop_group }}"
     mode: "600"
+  when: krb_create_principals_keytabs
 
 - import_role:
     name: tosit.tdp.utils.kerberos
@@ -25,3 +26,4 @@
     user: "root"
     group: "{{ hadoop_group }}"
     mode: "640"
+  when: krb_create_principals_keytabs

--- a/roles/hive/hiveserver2/tasks/kerberos.yml
+++ b/roles/hive/hiveserver2/tasks/kerberos.yml
@@ -6,24 +6,46 @@
     name: tosit.tdp.utils.kerberos
     tasks_from: install
 
-- import_role:
-    name: tosit.tdp.utils.kerberos
-    tasks_from: create_principal_keytab
-  vars:
-    principal: "hive/{{ ansible_fqdn }}"
-    keytab: "hive.service.keytab"
-    user: "{{ hive_user }}"
-    group: "{{ hadoop_group }}"
-    mode: "600"
+- block:
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: create_principal_keytab
+      vars:
+        principal: "hive/{{ ansible_fqdn }}"
+        keytab: "hive.service.keytab"
+        user: "{{ hive_user }}"
+        group: "{{ hadoop_group }}"
+        mode: "600"
+
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: create_principal_keytab
+      vars:
+        principal: "HTTP/{{ ansible_fqdn }}"
+        keytab: "spnego.service.keytab"
+        user: "root"
+        group: "{{ hadoop_group }}"
+        mode: "640"
   when: krb_create_principals_keytabs
 
-- import_role:
-    name: tosit.tdp.utils.kerberos
-    tasks_from: create_principal_keytab
-  vars:
-    principal: "HTTP/{{ ansible_fqdn }}"
-    keytab: "spnego.service.keytab"
-    user: "root"
-    group: "{{ hadoop_group }}"
-    mode: "640"
-  when: krb_create_principals_keytabs
+- block:
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: check_secure_keytab
+      vars:
+        principal: "hive/{{ ansible_fqdn }}"
+        keytab: "hive.service.keytab"
+        user: "{{ hive_user }}"
+        group: "{{ hadoop_group }}"
+        mode: "600"
+
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: check_secure_keytab
+      vars:
+        principal: "HTTP/{{ ansible_fqdn }}"
+        keytab: "spnego.service.keytab"
+        user: "root"
+        group: "{{ hadoop_group }}"
+        mode: "640"
+  when: not krb_create_principals_keytabs

--- a/roles/hive/metastore/tasks/kerberos.yml
+++ b/roles/hive/metastore/tasks/kerberos.yml
@@ -16,3 +16,14 @@
     group: "{{ hadoop_group }}"
     mode: "600"
   when: krb_create_principals_keytabs
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: check_secure_keytab
+  vars:
+    principal: "hive_ms/{{ ansible_fqdn }}"
+    keytab: "hive_ms.service.keytab"
+    user: "{{ hive_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "600"
+  when: not krb_create_principals_keytabs

--- a/roles/hive/metastore/tasks/kerberos.yml
+++ b/roles/hive/metastore/tasks/kerberos.yml
@@ -15,3 +15,4 @@
     user: "{{ hive_user }}"
     group: "{{ hadoop_group }}"
     mode: "600"
+  when: krb_create_principals_keytabs

--- a/roles/knox/gateway/tasks/kerberos.yml
+++ b/roles/knox/gateway/tasks/kerberos.yml
@@ -17,6 +17,17 @@
     mode: "600"
   when: krb_create_principals_keytabs
 
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: check_secure_keytab
+  vars:
+    principal: "knox/{{ ansible_fqdn }}"
+    keytab: "knox.service.keytab"
+    user: "{{ knox_user }}"
+    group: "{{ knox_group }}"
+    mode: "600"
+  when: not krb_create_principals_keytabs
+
 - name: Template Knox Gateway JAAS file
   template:
     src: krb5JAASLogin.conf.j2

--- a/roles/knox/gateway/tasks/kerberos.yml
+++ b/roles/knox/gateway/tasks/kerberos.yml
@@ -15,14 +15,15 @@
     user: "{{ knox_user }}"
     group: "{{ knox_group }}"
     mode: "600"
+  when: krb_create_principals_keytabs
 
 - name: Template Knox Gateway JAAS file
   template:
     src: krb5JAASLogin.conf.j2
-    dest: '{{ knox_conf_dir }}/krb5JAASLogin.conf'
+    dest: "{{ knox_conf_dir }}/krb5JAASLogin.conf"
 
 - name: Create symbolic link to krb5.conf
   file:
     src: /etc/krb5.conf
-    dest: '{{ knox_conf_dir }}/krb5.conf'
+    dest: "{{ knox_conf_dir }}/krb5.conf"
     state: link

--- a/roles/ranger/admin/tasks/kerberos.yml
+++ b/roles/ranger/admin/tasks/kerberos.yml
@@ -15,6 +15,7 @@
     user: "{{ ranger_user }}"
     group: "{{ hadoop_group }}"
     mode: "600"
+  when: krb_create_principals_keytabs
 
 - import_role:
     name: tosit.tdp.utils.kerberos
@@ -25,6 +26,7 @@
     user: "{{ ranger_user }}"
     group: "{{ hadoop_group }}"
     mode: "600"
+  when: krb_create_principals_keytabs
 
 - import_role:
     name: tosit.tdp.utils.kerberos
@@ -35,3 +37,4 @@
     user: "root"
     group: "{{ hadoop_group }}"
     mode: "640"
+  when: krb_create_principals_keytabs

--- a/roles/ranger/admin/tasks/kerberos.yml
+++ b/roles/ranger/admin/tasks/kerberos.yml
@@ -5,36 +5,66 @@
 - import_role:
     name: tosit.tdp.utils.kerberos
     tasks_from: install
+- block:
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: create_principal_keytab
+      vars:
+        principal: "rangerlookup/{{ ansible_fqdn }}"
+        keytab: "rangerlookup.service.keytab"
+        user: "{{ ranger_user }}"
+        group: "{{ hadoop_group }}"
+        mode: "600"
 
-- import_role:
-    name: tosit.tdp.utils.kerberos
-    tasks_from: create_principal_keytab
-  vars:
-    principal: "rangerlookup/{{ ansible_fqdn }}"
-    keytab: "rangerlookup.service.keytab"
-    user: "{{ ranger_user }}"
-    group: "{{ hadoop_group }}"
-    mode: "600"
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: create_principal_keytab
+      vars:
+        principal: "rangeradmin/{{ ansible_fqdn }}"
+        keytab: "rangeradmin.service.keytab"
+        user: "{{ ranger_user }}"
+        group: "{{ hadoop_group }}"
+        mode: "600"
+
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: create_principal_keytab
+      vars:
+        principal: "HTTP/{{ ansible_fqdn }}"
+        keytab: "spnego.service.keytab"
+        user: "root"
+        group: "{{ hadoop_group }}"
+        mode: "640"
   when: krb_create_principals_keytabs
 
-- import_role:
-    name: tosit.tdp.utils.kerberos
-    tasks_from: create_principal_keytab
-  vars:
-    principal: "rangeradmin/{{ ansible_fqdn }}"
-    keytab: "rangeradmin.service.keytab"
-    user: "{{ ranger_user }}"
-    group: "{{ hadoop_group }}"
-    mode: "600"
-  when: krb_create_principals_keytabs
+- block:
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: check_secure_keytab
+      vars:
+        principal: "rangerlookup/{{ ansible_fqdn }}"
+        keytab: "rangerlookup.service.keytab"
+        user: "{{ ranger_user }}"
+        group: "{{ hadoop_group }}"
+        mode: "600"
 
-- import_role:
-    name: tosit.tdp.utils.kerberos
-    tasks_from: create_principal_keytab
-  vars:
-    principal: "HTTP/{{ ansible_fqdn }}"
-    keytab: "spnego.service.keytab"
-    user: "root"
-    group: "{{ hadoop_group }}"
-    mode: "640"
-  when: krb_create_principals_keytabs
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: check_secure_keytab
+      vars:
+        principal: "rangeradmin/{{ ansible_fqdn }}"
+        keytab: "rangeradmin.service.keytab"
+        user: "{{ ranger_user }}"
+        group: "{{ hadoop_group }}"
+        mode: "600"
+
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: check_secure_keytab
+      vars:
+        principal: "HTTP/{{ ansible_fqdn }}"
+        keytab: "spnego.service.keytab"
+        user: "root"
+        group: "{{ hadoop_group }}"
+        mode: "640"
+  when: not krb_create_principals_keytabs

--- a/roles/ranger/usersync/tasks/kerberos.yml
+++ b/roles/ranger/usersync/tasks/kerberos.yml
@@ -15,3 +15,4 @@
     user: "{{ ranger_user }}"
     group: "{{ hadoop_group }}"
     mode: "600"
+  when: krb_create_principals_keytabs

--- a/roles/ranger/usersync/tasks/kerberos.yml
+++ b/roles/ranger/usersync/tasks/kerberos.yml
@@ -16,3 +16,14 @@
     group: "{{ hadoop_group }}"
     mode: "600"
   when: krb_create_principals_keytabs
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: check_secure_keytab
+  vars:
+    principal: "rangerusersync/{{ ansible_fqdn }}"
+    keytab: "rangerusersync.service.keytab"
+    user: "{{ ranger_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "600"
+  when: not krb_create_principals_keytabs

--- a/roles/spark/client/tasks/kerberos.yml
+++ b/roles/spark/client/tasks/kerberos.yml
@@ -10,7 +10,7 @@
     name: tosit.tdp.utils.kerberos
     tasks_from: create_headless_principal_keytab
   vars:
-    principal: "spark"
+    principal: "{{ spark_headless_principal }}"
     keytab: "spark.headless.keytab"
     user: "{{ spark_user }}"
     group: "{{ hadoop_group }}"
@@ -21,7 +21,7 @@
     name: tosit.tdp.utils.kerberos
     tasks_from: check_secure_keytab
   vars:
-    principal: "spark"
+    principal: "{{ spark_headless_principal }}"
     keytab: "spark.headless.keytab"
     user: "{{ spark_user }}"
     group: "{{ hadoop_group }}"

--- a/roles/spark/client/tasks/kerberos.yml
+++ b/roles/spark/client/tasks/kerberos.yml
@@ -15,3 +15,4 @@
     user: "{{ spark_user }}"
     group: "{{ hadoop_group }}"
     mode: "600"
+  when: krb_create_principals_keytabs

--- a/roles/spark/client/tasks/kerberos.yml
+++ b/roles/spark/client/tasks/kerberos.yml
@@ -16,3 +16,14 @@
     group: "{{ hadoop_group }}"
     mode: "600"
   when: krb_create_principals_keytabs
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: check_secure_keytab
+  vars:
+    principal: "spark"
+    keytab: "spark.headless.keytab"
+    user: "{{ spark_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "600"
+  when: not krb_create_principals_keytabs

--- a/roles/spark/common/tasks/hdfs_init.yml
+++ b/roles/spark/common/tasks/hdfs_init.yml
@@ -12,7 +12,7 @@
     group: "{{ item.group | default(omit) }}"
     mode: "{{ item.mode | default(omit) }}"
     kerberos: yes
-    krb_principal: "hdfs@{{ realm }}"
+    krb_principal: "{{ hdfs_headless_principal }}@{{ realm }}"
     krb_keytab: /etc/security/keytabs/hdfs.headless.keytab
   become: yes
   become_user: "{{ hdfs_user }}"

--- a/roles/spark/historyserver/tasks/kerberos.yml
+++ b/roles/spark/historyserver/tasks/kerberos.yml
@@ -10,24 +10,46 @@
     name: tosit.tdp.hadoop.common
     tasks_from: kerberos
 
-- import_role:
-    name: tosit.tdp.utils.kerberos
-    tasks_from: create_principal_keytab
-  vars:
-    principal: "spark/{{ ansible_fqdn }}"
-    keytab: "spark.service.keytab"
-    user: "{{ spark_user }}"
-    group: "{{ hadoop_group }}"
-    mode: "600"
+- block:
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: create_principal_keytab
+      vars:
+        principal: "spark/{{ ansible_fqdn }}"
+        keytab: "spark.service.keytab"
+        user: "{{ spark_user }}"
+        group: "{{ hadoop_group }}"
+        mode: "600"
+
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: create_principal_keytab
+      vars:
+        principal: "HTTP/{{ ansible_fqdn }}"
+        keytab: "spnego.service.keytab"
+        user: "root"
+        group: "{{ hadoop_group }}"
+        mode: "640"
   when: krb_create_principals_keytabs
 
-- import_role:
-    name: tosit.tdp.utils.kerberos
-    tasks_from: create_principal_keytab
-  vars:
-    principal: "HTTP/{{ ansible_fqdn }}"
-    keytab: "spnego.service.keytab"
-    user: "root"
-    group: "{{ hadoop_group }}"
-    mode: "640"
-  when: krb_create_principals_keytabs
+- block:
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: check_secure_keytab
+      vars:
+        principal: "spark/{{ ansible_fqdn }}"
+        keytab: "spark.service.keytab"
+        user: "{{ spark_user }}"
+        group: "{{ hadoop_group }}"
+        mode: "600"
+
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: check_secure_keytab
+      vars:
+        principal: "HTTP/{{ ansible_fqdn }}"
+        keytab: "spnego.service.keytab"
+        user: "root"
+        group: "{{ hadoop_group }}"
+        mode: "640"
+  when: not krb_create_principals_keytabs

--- a/roles/spark/historyserver/tasks/kerberos.yml
+++ b/roles/spark/historyserver/tasks/kerberos.yml
@@ -19,6 +19,7 @@
     user: "{{ spark_user }}"
     group: "{{ hadoop_group }}"
     mode: "600"
+  when: krb_create_principals_keytabs
 
 - import_role:
     name: tosit.tdp.utils.kerberos
@@ -29,3 +30,4 @@
     user: "root"
     group: "{{ hadoop_group }}"
     mode: "640"
+  when: krb_create_principals_keytabs

--- a/roles/utils/kerberos/tasks/check_secure_keytab.yml
+++ b/roles/utils/kerberos/tasks/check_secure_keytab.yml
@@ -1,0 +1,17 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Check kinit for {{ principal }}
+  shell: |
+    kinit -kt {{ keytabs_dir }}/{{ keytab }} {{ principal }}@{{ realm }} -c /tmp/check_keytab_cache
+    klist /tmp/check_keytab_cache | grep "Default principal: {{ principal }}@{{ realm }}"
+    rm -f /tmp/check_keytab_cache
+  changed_when: no
+
+- name: Set keytab permissions and ownership for {{ principal }}
+  file:
+    path: "{{ keytabs_dir }}/{{ keytab }}"
+    owner: "{{ user | default(omit) }}"
+    group: "{{ group | default(omit) }}"
+    mode: "{{ mode | default(omit) }}"

--- a/roles/yarn/apptimelineserver/tasks/kerberos.yml
+++ b/roles/yarn/apptimelineserver/tasks/kerberos.yml
@@ -20,3 +20,14 @@
     group: "{{ hadoop_group }}"
     mode: "600"
   when: krb_create_principals_keytabs
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: check_secure_keytab
+  vars:
+    principal: "ats/{{ ansible_fqdn }}"
+    keytab: "ats.service.keytab"
+    user: "{{ yarn_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "600"
+  when: not krb_create_principals_keytabs

--- a/roles/yarn/apptimelineserver/tasks/kerberos.yml
+++ b/roles/yarn/apptimelineserver/tasks/kerberos.yml
@@ -19,3 +19,4 @@
     user: "{{ yarn_user }}"
     group: "{{ hadoop_group }}"
     mode: "600"
+  when: krb_create_principals_keytabs

--- a/roles/yarn/client/tasks/kerberos.yml
+++ b/roles/yarn/client/tasks/kerberos.yml
@@ -15,3 +15,4 @@
     user: "{{ yarn_user }}"
     group: "{{ hadoop_group }}"
     mode: "600"
+  when: krb_create_principals_keytabs

--- a/roles/yarn/client/tasks/kerberos.yml
+++ b/roles/yarn/client/tasks/kerberos.yml
@@ -16,3 +16,14 @@
     group: "{{ hadoop_group }}"
     mode: "600"
   when: krb_create_principals_keytabs
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: check_secure_keytab
+  vars:
+    principal: "yarn"
+    keytab: "yarn.headless.keytab"
+    user: "{{ yarn_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "600"
+  when: not krb_create_principals_keytabs

--- a/roles/yarn/client/tasks/kerberos.yml
+++ b/roles/yarn/client/tasks/kerberos.yml
@@ -10,7 +10,7 @@
     name: tosit.tdp.utils.kerberos
     tasks_from: create_headless_principal_keytab
   vars:
-    principal: "yarn"
+    principal: "{{ yarn_headless_principal }}"
     keytab: "yarn.headless.keytab"
     user: "{{ yarn_user }}"
     group: "{{ hadoop_group }}"
@@ -21,7 +21,7 @@
     name: tosit.tdp.utils.kerberos
     tasks_from: check_secure_keytab
   vars:
-    principal: "yarn"
+    principal: "{{ yarn_headless_principal }}"
     keytab: "yarn.headless.keytab"
     user: "{{ yarn_user }}"
     group: "{{ hadoop_group }}"

--- a/roles/yarn/common/tasks/hdfs_init.yml
+++ b/roles/yarn/common/tasks/hdfs_init.yml
@@ -12,7 +12,7 @@
     group: "{{ item.group | default(omit) }}"
     mode: "{{ item.mode | default(omit) }}"
     kerberos: yes
-    krb_principal: "hdfs@{{ realm }}"
+    krb_principal: "{{ hdfs_headless_principal }}@{{ realm }}"
     krb_keytab: /etc/security/keytabs/hdfs.headless.keytab
   become: yes
   become_user: "{{ hdfs_user }}"
@@ -21,32 +21,32 @@
       state: directory
       owner: "{{ mapred_user }}"
       group: "{{ hadoop_group }}"
-      mode: '777'
+      mode: "777"
     - path: /mr-history/done
       state: directory
       owner: "{{ mapred_user }}"
       group: "{{ hadoop_group }}"
-      mode: '777'
+      mode: "777"
     - path: /mr-history/tmp
       state: directory
       owner: "{{ mapred_user }}"
       group: "{{ hadoop_group }}"
-      mode: '777'
+      mode: "777"
     - path: /app-logs
       state: directory
       owner: "{{ yarn_user }}"
       group: "{{ hadoop_group }}"
-      mode: '777'
+      mode: "777"
     - path: /ranger/audit/yarn
       state: directory
       owner: "{{ yarn_user }}"
       group: "{{ yarn_user }}"
-      mode: '700'
+      mode: "700"
     - path: /tmp
       state: directory
-      mode: '777'
+      mode: "777"
     - path: /tmp/hadoop-yarn/staging
       state: directory
       owner: "{{ yarn_user }}"
       group: "{{ hadoop_group }}"
-      mode: '1777'
+      mode: "1777"

--- a/roles/yarn/jobhistoryserver/tasks/kerberos.yml
+++ b/roles/yarn/jobhistoryserver/tasks/kerberos.yml
@@ -20,3 +20,14 @@
     group: "{{ hadoop_group }}"
     mode: "600"
   when: krb_create_principals_keytabs
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: check_secure_keytab
+  vars:
+    principal: "jhs/{{ ansible_fqdn }}"
+    keytab: "jhs.service.keytab"
+    user: "{{ mapred_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "600"
+  when: not krb_create_principals_keytabs

--- a/roles/yarn/jobhistoryserver/tasks/kerberos.yml
+++ b/roles/yarn/jobhistoryserver/tasks/kerberos.yml
@@ -19,3 +19,4 @@
     user: "{{ mapred_user }}"
     group: "{{ hadoop_group }}"
     mode: "600"
+  when: krb_create_principals_keytabs

--- a/roles/yarn/nodemanager/tasks/kerberos.yml
+++ b/roles/yarn/nodemanager/tasks/kerberos.yml
@@ -19,6 +19,7 @@
     user: "{{ yarn_user }}"
     group: "{{ hadoop_group }}"
     mode: "600"
+  when: krb_create_principals_keytabs
 
 - import_role:
     name: tosit.tdp.utils.kerberos
@@ -29,3 +30,4 @@
     user: "root"
     group: "{{ hadoop_group }}"
     mode: "640"
+  when: krb_create_principals_keytabs

--- a/roles/yarn/nodemanager/tasks/kerberos.yml
+++ b/roles/yarn/nodemanager/tasks/kerberos.yml
@@ -10,24 +10,46 @@
     name: tosit.tdp.hadoop.common
     tasks_from: kerberos
 
-- import_role:
-    name: tosit.tdp.utils.kerberos
-    tasks_from: create_principal_keytab
-  vars:
-    principal: "nm/{{ ansible_fqdn }}"
-    keytab: "nm.service.keytab"
-    user: "{{ yarn_user }}"
-    group: "{{ hadoop_group }}"
-    mode: "600"
+- block:
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: create_principal_keytab
+      vars:
+        principal: "nm/{{ ansible_fqdn }}"
+        keytab: "nm.service.keytab"
+        user: "{{ yarn_user }}"
+        group: "{{ hadoop_group }}"
+        mode: "600"
+
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: create_principal_keytab
+      vars:
+        principal: "HTTP/{{ ansible_fqdn }}"
+        keytab: "spnego.service.keytab"
+        user: "root"
+        group: "{{ hadoop_group }}"
+        mode: "640"
   when: krb_create_principals_keytabs
 
-- import_role:
-    name: tosit.tdp.utils.kerberos
-    tasks_from: create_principal_keytab
-  vars:
-    principal: "HTTP/{{ ansible_fqdn }}"
-    keytab: "spnego.service.keytab"
-    user: "root"
-    group: "{{ hadoop_group }}"
-    mode: "640"
-  when: krb_create_principals_keytabs
+- block:
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: check_secure_keytab
+      vars:
+        principal: "nm/{{ ansible_fqdn }}"
+        keytab: "nm.service.keytab"
+        user: "{{ yarn_user }}"
+        group: "{{ hadoop_group }}"
+        mode: "600"
+
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: check_secure_keytab
+      vars:
+        principal: "HTTP/{{ ansible_fqdn }}"
+        keytab: "spnego.service.keytab"
+        user: "root"
+        group: "{{ hadoop_group }}"
+        mode: "640"
+  when: not krb_create_principals_keytabs

--- a/roles/yarn/resourcemanager/tasks/kerberos.yml
+++ b/roles/yarn/resourcemanager/tasks/kerberos.yml
@@ -20,3 +20,14 @@
     group: "{{ hadoop_group }}"
     mode: "600"
   when: krb_create_principals_keytabs
+
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: check_secure_keytab
+  vars:
+    principal: "rm/{{ ansible_fqdn }}"
+    keytab: "rm.service.keytab"
+    user: "{{ yarn_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "600"
+  when: not krb_create_principals_keytabs

--- a/roles/yarn/resourcemanager/tasks/kerberos.yml
+++ b/roles/yarn/resourcemanager/tasks/kerberos.yml
@@ -19,3 +19,4 @@
     user: "{{ yarn_user }}"
     group: "{{ hadoop_group }}"
     mode: "600"
+  when: krb_create_principals_keytabs

--- a/roles/zookeeper/client/tasks/kerberos.yml
+++ b/roles/zookeeper/client/tasks/kerberos.yml
@@ -10,7 +10,7 @@
     name: tosit.tdp.utils.kerberos
     tasks_from: create_principal_keytab
   vars:
-    principal: "zookeeper"
+    principal: "{{ zookeeper_headless_principal }}"
     keytab: "zookeeper.headless.keytab"
     user: "{{ zookeeper_user }}"
     group: "{{ hadoop_group }}"
@@ -21,7 +21,7 @@
     name: tosit.tdp.utils.kerberos
     tasks_from: check_secure_keytab
   vars:
-    principal: "zookeeper"
+    principal: "{{ zookeeper_headless_principal }}"
     keytab: "zookeeper.headless.keytab"
     user: "{{ zookeeper_user }}"
     group: "{{ hadoop_group }}"

--- a/roles/zookeeper/client/tasks/kerberos.yml
+++ b/roles/zookeeper/client/tasks/kerberos.yml
@@ -15,6 +15,7 @@
     user: "{{ zookeeper_user }}"
     group: "{{ hadoop_group }}"
     mode: "600"
+  when: krb_create_principals_keytabs
 
 - name: Template jaas.conf
   template:

--- a/roles/zookeeper/client/tasks/kerberos.yml
+++ b/roles/zookeeper/client/tasks/kerberos.yml
@@ -17,6 +17,17 @@
     mode: "600"
   when: krb_create_principals_keytabs
 
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: check_secure_keytab
+  vars:
+    principal: "zookeeper"
+    keytab: "zookeeper.headless.keytab"
+    user: "{{ zookeeper_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "600"
+  when: not krb_create_principals_keytabs
+
 - name: Template jaas.conf
   template:
     src: jaas.client.conf.j2

--- a/roles/zookeeper/common/templates/jaas.client.conf.j2
+++ b/roles/zookeeper/common/templates/jaas.client.conf.j2
@@ -4,5 +4,5 @@ Client {
   keyTab="/etc/security/keytabs/zookeeper.headless.keytab"
   storeKey=true
   useTicketCache=false
-  principal="zookeeper@{{ realm }}";
+  principal="{{ zookeeper_headless_principal }}@{{ realm }}";
 };

--- a/roles/zookeeper/server/tasks/kerberos.yml
+++ b/roles/zookeeper/server/tasks/kerberos.yml
@@ -15,6 +15,7 @@
     user: "{{ zookeeper_user }}"
     group: "{{ hadoop_group }}"
     mode: "600"
+  when: krb_create_principals_keytabs
 
 - name: Template jaas.conf
   template:

--- a/roles/zookeeper/server/tasks/kerberos.yml
+++ b/roles/zookeeper/server/tasks/kerberos.yml
@@ -17,6 +17,17 @@
     mode: "600"
   when: krb_create_principals_keytabs
 
+- import_role:
+    name: tosit.tdp.utils.kerberos
+    tasks_from: check_secure_keytab
+  vars:
+    principal: "zookeeper/{{ ansible_fqdn }}"
+    keytab: "zookeeper.service.keytab"
+    user: "{{ zookeeper_user }}"
+    group: "{{ hadoop_group }}"
+    mode: "600"
+  when: not krb_create_principals_keytabs
+
 - name: Template jaas.conf
   template:
     src: jaas.server.conf.j2

--- a/tdp_vars_defaults/hadoop/hadoop.yml
+++ b/tdp_vars_defaults/hadoop/hadoop.yml
@@ -52,11 +52,18 @@ jmx_exporter_nm_opts: "{% if 'exporter_jmx' in groups and groups['exporter_jmx']
 jmx_exporter_ats_opts: "{% if 'exporter_jmx' in groups and groups['exporter_jmx'] %}-javaagent:{{ jmx_exporter_install_file }}=18107:{{ jmx_exporter_conf_dir }}/ats.yml{% else %}{% endif %}"
 jmx_exporter_jhs_opts: "{% if 'exporter_jmx' in groups and groups['exporter_jmx'] %}-javaagent:{{ jmx_exporter_install_file }}=18108:{{ jmx_exporter_conf_dir }}/jhs.yml{% else %}{% endif %}"
 
-
 # Hadoop logging directory
 hadoop_log_dir: /var/log/hadoop
 hadoop_env_client_log_dir: /var/log/hadoop/$USER
 hadoop_log4j_client_log_dir: .
+
+# Kerberos
+###
+# Set to 'no' to skip service principals and keytabs creation.
+# This can be useful if TDP operators don't have admin access to the Kerberos server,
+# or if the Kerberos server does not support MIT Kerberos tools.
+###
+krb_create_principals_keytabs: yes
 
 # SSL Keystore and Truststore
 hadoop_keystore_location: /etc/ssl/certs/keystore.jks
@@ -94,7 +101,7 @@ hadoop_ha_zookeeper_quorum: |
      map('regex_replace', '^(.*)$', '\1:' + (zookeeper_server_client_port | string)) |
      list |
      join(',') }}
-     
+
 # core-site.xml - common
 core_site:
   fs.defaultFS: "hdfs://mycluster"
@@ -153,10 +160,10 @@ mapred_site:
   mapreduce.jobhistory.keytab: /etc/security/keytabs/jhs.service.keytab
   mapreduce.jobhistory.bind-host: 0.0.0.0
   mapreduce.cluster.acls.enabled: true
-  mapreduce.cluster.administrators: mapred,yarn,knox 
-  mapreduce.jobhistory.admin.acl: "*" 
+  mapreduce.cluster.administrators: mapred,yarn,knox
+  mapreduce.jobhistory.admin.acl: "*"
   mapreduce.jobhistory.http.policy: HTTPS_ONLY
-  mapreduce.jobhistory.webapp.spnego-principal: HTTP/_HOST@{{ realm }} 
+  mapreduce.jobhistory.webapp.spnego-principal: HTTP/_HOST@{{ realm }}
   mapreduce.jobhistory.webapp.spnego-keytab-file: /etc/security/keytabs/spnego.service.keytab
   ###
   # The yarn.app.mapreduce.am.job.client.port-range property controls the pool of ports available to MR job application masters.
@@ -177,7 +184,7 @@ jmx_exporter:
   lowercaseOutputName: false
   lowercaseOutputLabelNames: false
 
-# Ranger KMS url 
+# Ranger KMS url
 ranger_kms_url: "{% if 'ranger_kms' in groups and groups['ranger_kms'] %}kms://https@{{ ranger_kms_hosts }}:9393/kms{% else %}NONE{% endif %}"
 ranger_kms_hosts: |-
   {% if 'ranger_kms' in groups and groups['ranger_kms'] %}

--- a/tdp_vars_defaults/hadoop/hadoop.yml
+++ b/tdp_vars_defaults/hadoop/hadoop.yml
@@ -64,6 +64,13 @@ hadoop_log4j_client_log_dir: .
 # or if the Kerberos server does not support MIT Kerberos tools.
 ###
 krb_create_principals_keytabs: yes
+zookeeper_headless_principal: zookeeper
+hdfs_headless_principal: hdfs
+yarn_headless_principal: yarn
+mapred_headless_principal: mapred
+hbase_headless_principal: hbase
+hive_headless_principal: hive
+spark_headless_principal: spark
 
 # SSL Keystore and Truststore
 hadoop_keystore_location: /etc/ssl/certs/keystore.jks
@@ -115,6 +122,13 @@ core_site:
     RULE:[2:$1/$2@$0]([rn]m/.*@{{ realm }})s/.*/yarn/
     RULE:[2:$1/$2@$0](jhs/.*@{{ realm }})s/.*/mapred/
     RULE:[2:$1/$2@$0](hive/.*@{{ realm }})s/.*/hive/
+    RULE:[1:$1@$0]({{ hdfs_headless_principal }}@{{ realm }})s/.*/hdfs/
+    RULE:[1:$1@$0]({{ yarn_headless_principal }}@{{ realm }})s/.*/yarn/
+    RULE:[1:$1@$0]({{ mapred_headless_principal }}@{{ realm }})s/.*/mapred/
+    RULE:[1:$1@$0]({{ hive_headless_principal }}@{{ realm }})s/.*/hive/
+    RULE:[1:$1@$0]({{ zookeeper_headless_principal }}@{{ realm }})s/.*/zookeeper/
+    RULE:[1:$1@$0]({{ hbase_headless_principal }}@{{ realm }})s/.*/hbase/
+    RULE:[1:$1@$0]({{ spark_headless_principal }}@{{ realm }})s/.*/spark/
     DEFAULT
   hadoop.proxyuser.hbase.groups: "*"
   hadoop.proxyuser.hbase.hosts: "*"

--- a/tdp_vars_defaults/hbase/hbase.yml
+++ b/tdp_vars_defaults/hbase/hbase.yml
@@ -48,6 +48,14 @@ hbase_pid_dir: /var/run/hbase
 # HBase logging directory
 hbase_log_dir: /var/log/hbase
 
+# Kerberos
+###
+# Set to 'no' to skip service principals and keytabs creation.
+# This can be useful if TDP operators don't have admin access to the Kerberos server,
+# or if the Kerberos server does not support MIT Kerberos tools.
+###
+krb_create_principals_keytabs: yes
+
 # SSL Keystore and Truststore
 hbase_keystore_location: /etc/ssl/certs/keystore.jks
 hbase_keystore_password: Keystore123!
@@ -68,7 +76,6 @@ hbase_zookeeper_quorum: |
      list |
      join(',') }}
 hbase_zookeeper_client_port: "2181"
-
 # hbase_site.xml - common
 # TODO: make a hbase_site per service: master, rs, rest, client, phoenix queryserver
 hbase_site:

--- a/tdp_vars_defaults/hive/hive.yml
+++ b/tdp_vars_defaults/hive/hive.yml
@@ -42,6 +42,14 @@ hive_ms_db_user: hive
 hive_ms_db_password: hive123
 db_type: mysql
 
+# Kerberos
+###
+# Set to 'no' to skip service principals and keytabs creation.
+# This can be useful if TDP operators don't have admin access to the Kerberos server,
+# or if the Kerberos server does not support MIT Kerberos tools.
+###
+krb_create_principals_keytabs: yes
+
 # SSL Keystore and Truststore
 hive_keystore_location: /etc/ssl/certs/keystore.jks
 hive_keystore_password: Keystore123!
@@ -50,7 +58,7 @@ hive_truststore_password: Truststore123!
 
 # hive-site.xml - common
 hive_site:
-# javax.jdo.option.ConnectionURL: "{{ hive_ms_db_url }}/{{ hive_ms_db_name }}"
+  # javax.jdo.option.ConnectionURL: "{{ hive_ms_db_url }}/{{ hive_ms_db_name }}"
   datanucleus.schema.auto: "false"
   javax.jdo.option.ConnectionDriverName: com.mysql.jdbc.Driver
   javax.jdo.option.ConnectionUserName: "{{ hive_ms_db_user }}"

--- a/tdp_vars_defaults/knox/knox.yml
+++ b/tdp_vars_defaults/knox/knox.yml
@@ -31,6 +31,14 @@ knox_data_dir: /var/lib/knox
 # Knox Keystore directory
 knox_keystore_dir: "{{ knox_data_dir }}/data/security/keystores"
 
+# Kerberos
+###
+# Set to 'no' to skip service principals and keytabs creation.
+# This can be useful if TDP operators don't have admin access to the Kerberos server,
+# or if the Kerberos server does not support MIT Kerberos tools.
+###
+krb_create_principals_keytabs: yes
+
 # SSL Keystore and Truststore
 knox_keystore_location: "{{ knox_keystore_dir }}/gateway.jks"
 knox_keystore_password: Keystore123!

--- a/tdp_vars_defaults/ranger/ranger.yml
+++ b/tdp_vars_defaults/ranger/ranger.yml
@@ -42,6 +42,14 @@ ranger_tagsync_password: RangerTagsync123
 ranger_usersync_password: RangerUsersync123
 ranger_keyadmin_password: RangerKeyAdmin123
 
+# Kerberos
+###
+# Set to 'no' to skip service principals and keytabs creation.
+# This can be useful if TDP operators don't have admin access to the Kerberos server,
+# or if the Kerberos server does not support MIT Kerberos tools.
+###
+krb_create_principals_keytabs: yes
+
 # SSL Keystore and Truststore
 ranger_keystore_location: /etc/ssl/certs/keystore.jks
 ranger_keystore_password: Keystore123!
@@ -61,7 +69,7 @@ install_properties:
   db_user: rangeradmin
   db_password: rangeradmin
   # Note: db is deprecated but keeps the setup.sh script from requesting a solr endpoint
-  audit_store: "{% if 'ranger_solr' in groups and groups['ranger_solr'] %}solr{% else %}db{% endif %}" 
+  audit_store: "{% if 'ranger_solr' in groups and groups['ranger_solr'] %}solr{% else %}db{% endif %}"
   audit_solr_urls: "{% if 'ranger_solr' in groups and groups['ranger_solr'] %}http://{{ groups['ranger_solr'][0] | tosit.tdp.access_fqdn(hostvars) }}:8983/solr/ranger_audits{% else %}{% endif %}"
 
 # Ranger KMS install.properties
@@ -76,7 +84,7 @@ kms_install_properties:
   POLICY_MGR_URL: "https://{{ groups['ranger_admin'][0] | tosit.tdp.access_fqdn(hostvars) }}:6182"
   REPOSITORY_NAME: kms-tdp
   XAAUDIT_SOLR_ENABLE: "{% if 'ranger_solr' in groups and groups['ranger_solr'] %}true{% else %}false{% endif %}"
-  XAAUDIT_SOLR_URL: "{% if 'ranger_solr' in groups and groups['ranger_solr'] %}http://{{ groups['ranger_solr'][0] | tosit.tdp.access_fqdn(hostvars) }}:8983/solr/ranger_audits{% else %}NONE{% endif %}"  
+  XAAUDIT_SOLR_URL: "{% if 'ranger_solr' in groups and groups['ranger_solr'] %}http://{{ groups['ranger_solr'][0] | tosit.tdp.access_fqdn(hostvars) }}:8983/solr/ranger_audits{% else %}NONE{% endif %}"
 
 # Ranger Usersync install.properties
 usersync_install_properties:
@@ -94,7 +102,6 @@ usersync_install_properties:
 ranger_admin_restart: "no"
 ranger_usync_restart: "no"
 ranger_kms_restart: "no"
-
 
 # Solr version
 solr_release: solr-7.7.3

--- a/tdp_vars_defaults/spark/spark.yml
+++ b/tdp_vars_defaults/spark/spark.yml
@@ -39,6 +39,14 @@ hadoop_conf_dir: /etc/hadoop/conf
 hadoop_home: "/opt/tdp/hadoop"
 hdfs_user: hdfs
 
+# Kerberos
+###
+# Set to 'no' to skip service principals and keytabs creation.
+# This can be useful if TDP operators don't have admin access to the Kerberos server,
+# or if the Kerberos server does not support MIT Kerberos tools.
+###
+krb_create_principals_keytabs: yes
+
 # SSL Keystore and Truststore
 spark_keystore_location: /etc/ssl/certs/keystore.jks
 spark_keystore_password: Keystore123!
@@ -74,7 +82,7 @@ spark_defaults_client:
   spark.hadoop.yarn.timeline-service.enabled: "false"
   spark.yarn.historyServer.address: "{{ groups['spark_hs'][0] | tosit.tdp.access_fqdn(hostvars) }}:18081"
   spark.master: yarn
-  # Hive configuration 
+  # Hive configuration
   spark.datasource.hive.warehouse.metastoreUri: |-
     {{ groups['hive_ms'] | 
       map('tosit.tdp.access_fqdn', hostvars) |

--- a/tdp_vars_defaults/spark3/spark3.yml
+++ b/tdp_vars_defaults/spark3/spark3.yml
@@ -34,6 +34,14 @@ hadoop_conf_dir: /etc/hadoop/conf
 hadoop_home: "/opt/tdp/hadoop"
 hdfs_user: hdfs
 
+# Kerberos
+###
+# Set to 'no' to skip service principals and keytabs creation.
+# This can be useful if TDP operators don't have admin access to the Kerberos server,
+# or if the Kerberos server does not support MIT Kerberos tools.
+###
+krb_create_principals_keytabs: yes
+
 # SSL Keystore and Truststore
 spark_keystore_location: /etc/ssl/certs/keystore.jks
 spark_keystore_password: Keystore123!
@@ -70,7 +78,7 @@ spark_defaults_client:
   spark.yarn.historyServer.address: "{{ groups['spark3_hs'][0] | tosit.tdp.access_fqdn(hostvars) }}:18081"
   spark.yarn.appMasterEnv.PYSPARK_PYTHON: python3
   spark.master: yarn
-  # Hive configuration 
+  # Hive configuration
   spark.datasource.hive.warehouse.metastoreUri: |-
     {{ groups['hive_ms'] | 
       map('tosit.tdp.access_fqdn', hostvars) |

--- a/tdp_vars_defaults/zookeeper/zookeeper.yml
+++ b/tdp_vars_defaults/zookeeper/zookeeper.yml
@@ -55,6 +55,14 @@ zookeeper_root_logger: INFO,ROLLINGFILE
 zookeeper_console_threshold: INFO
 zookeeper_log_threshold: DEBUG
 
+# Kerberos
+###
+# Set to 'no' to skip service principals and keytabs creation.
+# This can be useful if TDP operators don't have admin access to the Kerberos server,
+# or if the Kerberos server does not support MIT Kerberos tools.
+###
+krb_create_principals_keytabs: yes
+
 # ZooKeeper component & service check
 zookeeper_check_retries: 0
 zookeeper_check_delay: 5


### PR DESCRIPTION
<!--  Thank you for sending a pull request! Please make sure:

1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes:
<!--
Example: "Fixes #(issue number)" or "Fixes (link of issue)".
-->
Fixes #359 

#### Additional comments:
<!--
Example: `"I was not sure if it is the right way to do but..."
-->

This PR allows disabling principals and keytabs creation with the `krb_create_principals_keytabs` variable. If the variable is set to `no|false`, the roles will check that the keytabs are present in `/etc/security/keytabs` and contain the correct principals.

The PR also adds the ability to customize the name of the headless principals. This can be useful in the case multiple clusters share the same Kerberos realm to avoid principal overlapping (e.g. `hdfs_headless_principal: hdfs-cluster[1|2]`).

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to [TOSIT](https://www.tosit.io/),
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.

