### PR TITLE
dag: add ranger_*_config missed dependencies

### DIFF
--- a/tdp_lib_dag/hdfs.yml
+++ b/tdp_lib_dag/hdfs.yml
@@ -43,6 +43,8 @@
 
 - name: hdfs_namenode_config
   depends_on:
+    - ranger_admin_config
+    - ranger_kms_config
     - zookeeper_config
     - hadoop_client_config
     - hdfs_kerberos_install

--- a/tdp_lib_dag/hive.yml
+++ b/tdp_lib_dag/hive.yml
@@ -49,6 +49,7 @@
 
 - name: hive_hiveserver2_config
   depends_on:
+    - ranger_admin_config
     - zookeeper_config
     - hadoop_client_config
     - hive_kerberos_install

--- a/tdp_lib_dag/knox.yml
+++ b/tdp_lib_dag/knox.yml
@@ -24,13 +24,13 @@
 
 - name: knox_gateway_config
   depends_on:
+    - ranger_admin_config
     - hadoop_client_config
     - knox_kerberos_install
     - knox_ssl-tls_install
 
 - name: knox_ranger_config
   depends_on:
-    - ranger_admin_config
     - knox_ranger_install
     - knox_gateway_config
 

--- a/tdp_lib_dag/yarn.yml
+++ b/tdp_lib_dag/yarn.yml
@@ -52,6 +52,7 @@
 
 - name: yarn_resourcemanager_config
   depends_on:
+    - ranger_admin_config
     - hdfs_client_config
     - yarn_kerberos_install
     - yarn_ssl-tls_install


### PR DESCRIPTION
<!--  Thank you for sending a pull request! Please make sure:

1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes:
<!--
Example: "Fixes #(issue number)" or "Fixes (link of issue)".
-->
Fixes #393 

#### Additional comments:
<!--
Example: `"I was not sure if it is the right way to do but..."
-->

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to [TOSIT](https://www.tosit.io/),
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.

PS : Please note that the dag was not impacted by this change 

**New restart_required Trace :**
```
2022-08-02 15:59:09,040    ranger_admin_config.yml
2022-08-02 15:59:09,041    ranger_jmx-exporter_config.yml
2022-08-02 15:59:09,041    ranger_admin_restart.yml
2022-08-02 15:59:09,041    ranger_kms_config.yml
2022-08-02 15:59:09,041    ranger_usersync_config.yml
2022-08-02 15:59:09,041    ranger_usersync_restart.yml
2022-08-02 15:59:09,041    ranger_kms_restart.yml
2022-08-02 15:59:09,042    hdfs_namenode_config.yml
2022-08-02 15:59:09,042    hdfs_client_config.yml
2022-08-02 15:59:09,042    hdfs_journalnode_restart.yml
2022-08-02 15:59:09,042    hdfs_ranger_config.yml
2022-08-02 15:59:09,042    hdfs_namenode_restart.yml
2022-08-02 15:59:09,042    hdfs_datanode_restart.yml
2022-08-02 15:59:09,043    yarn_apptimelineserver_config.yml
2022-08-02 15:59:09,043    yarn_apptimelineserver_restart.yml
2022-08-02 15:59:09,043    yarn_mapred_jobhistoryserver_config.yml
2022-08-02 15:59:09,043    yarn_mapred_jobhistoryserver_restart.yml
2022-08-02 15:59:09,043    yarn_nodemanager_config.yml
2022-08-02 15:59:09,043    yarn_resourcemanager_config.yml
2022-08-02 15:59:09,043    yarn_client_config.yml
2022-08-02 15:59:09,044    yarn_ranger_config.yml
2022-08-02 15:59:09,044    yarn_resourcemanager_restart.yml
2022-08-02 15:59:09,044    yarn_nodemanager_restart.yml
2022-08-02 15:59:09,044    hive_client_config.yml
2022-08-02 15:59:09,044    hive_hiveserver2_config.yml
2022-08-02 15:59:09,044    hive_metastore_restart.yml
2022-08-02 15:59:09,045    hive_ranger_config.yml
2022-08-02 15:59:09,045    hive_hiveserver2_restart.yml
2022-08-02 15:59:09,045    hbase_client_config.yml
2022-08-02 15:59:09,045    hbase_master_config.yml
2022-08-02 15:59:09,045    hbase_phoenix_queryserver_client_config.yml
2022-08-02 15:59:09,045    hbase_phoenix_queryserver_daemon_config.yml
2022-08-02 15:59:09,045    hbase_regionserver_config.yml
2022-08-02 15:59:09,046    hbase_ranger_config.yml
2022-08-02 15:59:09,046    hbase_master_restart.yml
2022-08-02 15:59:09,046    hbase_regionserver_restart.yml
2022-08-02 15:59:09,046    hbase_rest_config.yml
2022-08-02 15:59:09,046    hbase_rest_restart.yml
2022-08-02 15:59:09,046    hbase_phoenix_queryserver_daemon_restart.yml
2022-08-02 15:59:09,047    spark_historyserver_restart.yml
2022-08-02 15:59:09,047    spark3_historyserver_restart.yml
2022-08-02 15:59:09,047    knox_gateway_config.yml
2022-08-02 15:59:09,047    knox_ranger_config.yml
2022-08-02 15:59:09,047    knox_gateway_restart.yml

```