### PR TITLE
fix(spark): specify right path for hive_conf_dir

### DIFF
--- a/tdp_vars_defaults/spark/spark.yml
+++ b/tdp_vars_defaults/spark/spark.yml
@@ -8,7 +8,7 @@ spark_release: spark-2.3.5-TDP-0.1.0-SNAPSHOT-bin-tdp
 spark_dist_file: "{{ spark_release }}.tgz"
 spark_hbase_dist_file: hbase-spark-2.3.5-1.0.0-TDP-0.1.0-SNAPSHOT.jar
 
-# Spark HBase Connector 
+# Spark HBase Connector
 spark_hbase_connector_enable: true
 
 # Spark users and group
@@ -120,6 +120,7 @@ spark_defaults_hs:
 spark_env_common:
   HADOOP_CONF_DIR: "{{ hadoop_conf_dir }}"
   HADOOP_HOME: "{{ hadoop_home }}"
+  HIVE_CONF_DIR: "{{ spark_client_conf_dir }}"
   LD_LIBRARY_PATH: "'{{ hadoop_home }}/lib/native/:$LD_LIBRARY_PATH'"
 
 # spark-env.sh - Spark History Server

--- a/tdp_vars_defaults/spark3/spark3.yml
+++ b/tdp_vars_defaults/spark3/spark3.yml
@@ -7,7 +7,7 @@ spark_version: spark3
 spark_release: spark-3.2.2-TDP-0.1.0-SNAPSHOT-bin-tdp
 spark_dist_file: "{{ spark_release }}.tgz"
 
-# Spark HBase Connector 
+# Spark HBase Connector
 spark_hbase_connector_enable: false
 
 # Spark users and group
@@ -117,6 +117,7 @@ spark_env_common:
   PYSPARK_PYTHON: python3
   HADOOP_CONF_DIR: "{{ hadoop_conf_dir }}"
   HADOOP_HOME: "{{ hadoop_home }}"
+  HIVE_CONF_DIR: "{{ spark_client_conf_dir }}"
   LD_LIBRARY_PATH: "'{{ hadoop_home }}/lib/native/:$LD_LIBRARY_PATH'"
 
 # spark-env.sh - Spark History Server


### PR DESCRIPTION
<!--  Thank you for sending a pull request! Please make sure:

1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes:
<!--
Example: "Fixes #(issue number)" or "Fixes (link of issue)".
-->
Fixes #394
Fixes #395 

#### Additional comments:
<!--
Example: `"I was not sure if it is the right way to do but..."
-->

It appears that Spark is loading configuration from `/etc/hive/conf` by default. This is undocumented but I assume this comes from the default behavior of the HiveConf loading classes. Setting `HIVE_CONF_DIR` to the Spark conf dir allows loading the `hive-site.xml` generated for Spark.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to [TOSIT](https://www.tosit.io/),
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.

