### PR TITLE
fix(yarn): add resourcemanager spnego keytab creation

### DIFF
--- a/roles/yarn/resourcemanager/tasks/kerberos.yml
+++ b/roles/yarn/resourcemanager/tasks/kerberos.yml
@@ -10,24 +10,46 @@
     name: tosit.tdp.hadoop.common
     tasks_from: kerberos
 
-- import_role:
-    name: tosit.tdp.utils.kerberos
-    tasks_from: create_principal_keytab
-  vars:
-    principal: "rm/{{ ansible_fqdn }}"
-    keytab: "rm.service.keytab"
-    user: "{{ yarn_user }}"
-    group: "{{ hadoop_group }}"
-    mode: "600"
+- block:
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: create_principal_keytab
+      vars:
+        principal: "rm/{{ ansible_fqdn }}"
+        keytab: "rm.service.keytab"
+        user: "{{ yarn_user }}"
+        group: "{{ hadoop_group }}"
+        mode: "600"
+
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: create_principal_keytab
+      vars:
+        principal: "HTTP/{{ ansible_fqdn }}"
+        keytab: "spnego.service.keytab"
+        user: "root"
+        group: "{{ hadoop_group }}"
+        mode: "640"
   when: krb_create_principals_keytabs
 
-- import_role:
-    name: tosit.tdp.utils.kerberos
-    tasks_from: check_secure_keytab
-  vars:
-    principal: "rm/{{ ansible_fqdn }}"
-    keytab: "rm.service.keytab"
-    user: "{{ yarn_user }}"
-    group: "{{ hadoop_group }}"
-    mode: "600"
+- block:
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: check_secure_keytab
+      vars:
+        principal: "rm/{{ ansible_fqdn }}"
+        keytab: "rm.service.keytab"
+        user: "{{ yarn_user }}"
+        group: "{{ hadoop_group }}"
+        mode: "600"
+
+    - import_role:
+        name: tosit.tdp.utils.kerberos
+        tasks_from: check_secure_keytab
+      vars:
+        principal: "HTTP/{{ ansible_fqdn }}"
+        keytab: "spnego.service.keytab"
+        user: "root"
+        group: "{{ hadoop_group }}"
+        mode: "640"
   when: not krb_create_principals_keytabs


### PR DESCRIPTION
<!--  Thank you for sending a pull request! Please make sure:

1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes:
<!--
Example: "Fixes #(issue number)" or "Fixes (link of issue)".
-->
Fixes #407 
#### Additional comments:
<!--
Example: `"I was not sure if it is the right way to do but..."
-->
This PR will remove Yarn dependency to HDFS by making sure that the `spnego.service.keytab` file is created on nodes where Resource Manager is installed.

----
To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to [TOSIT](https://www.tosit.io/),
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.

