### PR TITLE
fix(topology): ansible group can not used bracket in topology

### DIFF
--- a/topology.ini
+++ b/topology.ini
@@ -9,7 +9,9 @@ worker
 edge
 
 [zk:children]
-master[1:3]
+master1
+master2
+master3
 
 [zk_client:children]
 master
@@ -28,22 +30,27 @@ master3
 master3
 
 [ranger_kms:children]
-master[2:3]
+master2
+master3
 
 [ranger_usersync:children]
 master3
 
 [hdfs_nn:children]
-master[1:2]
+master1
+master2
 
 [hdfs_jn:children]
-master[1:3]
+master1
+master2
+master3
 
 [hdfs_dn:children]
 worker
 
 [yarn_rm:children]
-master[1:2]
+master1
+master2
 
 [yarn_nm:children]
 worker
@@ -55,16 +62,19 @@ master3
 master3
 
 [hive_s2:children]
-master[2:3]
+master2
+master3
 
 [hive_ms:children]
-master[2:3]
+master2
+master3
 
 [hive_client:children]
 edge
 
 [hbase_master:children]
-master[1:2]
+master1
+master2
 
 [hbase_rs:children]
 worker


### PR DESCRIPTION
<!--  Thank you for sending a pull request! Please make sure:

1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes:
<!--
Example: "Fixes #(issue number)" or "Fixes (link of issue)".
-->
Fixes #413 

#### Additional comments:
<!--
Example: `"I was not sure if it is the right way to do but..."
-->

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to [TOSIT](https://www.tosit.io/),
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.

