### PR TITLE
feat(hive): change hive ms default database password

### DIFF
--- a/tdp_vars_defaults/hive/hive.yml
+++ b/tdp_vars_defaults/hive/hive.yml
@@ -39,7 +39,7 @@ hive_jdbc_connector_package: mysql-connector-java
 hive_ms_db_url: jdbc:mysql://tdp-db-1.lxd:3306
 hive_ms_db_name: hive
 hive_ms_db_user: hive
-hive_ms_db_password: hive123
+hive_ms_db_password: hive
 db_type: mysql
 
 # Kerberos


### PR DESCRIPTION
Delete "123" which is not consistent with Ranger Admin and Ranger KMS default database password.

<!--  Thank you for sending a pull request! Please make sure:

1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes:
<!--
Example: "Fixes #(issue number)" or "Fixes (link of issue)".
-->
Fixes #415 

#### Additional comments:
<!--
Example: `"I was not sure if it is the right way to do but..."
-->

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to [TOSIT](https://www.tosit.io/),
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.

