### PR TITLE
feat(utils): add ranger_policies role, playbook, and module

### DIFF
--- a/playbooks/utils/ranger_policies.yml
+++ b/playbooks/utils/ranger_policies.yml
@@ -1,0 +1,13 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Ranger Admin configure policies
+  hosts: edge
+  strategy: linear
+  tasks:
+    - tosit.tdp.resolve:
+        node_name: ranger_admin
+    - import_role:
+        name: tosit.tdp.utils.ranger_policies
+    - meta: clear_facts

--- a/plugins/modules/ranger_policy.py
+++ b/plugins/modules/ranger_policy.py
@@ -1,0 +1,160 @@
+#! /usr/bin/env python
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+# -*- coding: utf-8 -*-
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+import os
+from ansible.module_utils._text import to_native
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common._collections_compat import Mapping, Sequence
+from ansible.module_utils.six import iteritems, string_types, text_type
+from ansible.module_utils.six.moves.urllib.parse import quote as urlquote
+from ansible.module_utils.urls import fetch_url, url_argument_spec
+
+def ranger_json_deep_equal(a, b):
+    """Custom comparison of two objects.
+    If objects are Mapping (dict) and if B has a missing key from A return False. If B has additional keys returns True.
+    Ranger Admin can return JSON with additional keys and we should ignore it.
+    """
+    if isinstance(a, Mapping) and isinstance(b, Mapping):
+        for key_a, value_a in iteritems(a):
+            if key_a not in b:
+                return False
+            if not ranger_json_deep_equal(value_a, b[key_a]):
+                return False
+    # "string_types" is a "Sequence", to avoid infinite recursion perform direct comparison
+    elif isinstance(a, string_types) and isinstance(b, string_types):
+        # Convert to unicode before comparison
+        return text_type(a) == text_type(b)
+    elif isinstance(a, Sequence) and isinstance(b, Sequence):
+        if len(a) != len(b):
+            return False
+        for value_a, value_b in zip(a, b):
+            if not ranger_json_deep_equal(value_a, value_b):
+                return False
+    return a == b
+
+def dict_del_key(a, b):
+    """Remove keys in B that are not in A recursively"""
+    if isinstance(a, Mapping) and isinstance(b, Mapping):
+        for key_b in list(b.keys()):
+            if key_b not in a:
+                del b[key_b]
+            else:
+                dict_del_key(a[key_b], b[key_b])
+    # "string_types" is a "Sequence", to avoid infinite recursion return
+    elif isinstance(a, string_types) and isinstance(b, string_types):
+        return
+    elif isinstance(a, Sequence) and isinstance(b, Sequence):
+        for value_a, value_b in zip(a, b):
+            dict_del_key(value_a, value_b)
+
+def main():
+    argument_spec = url_argument_spec()
+    argument_spec.update(
+        policy_mgr_url=dict(type='str', required=True),
+        policy=dict(type='dict', required=True),
+        state=dict(type='str', choices=['present', 'absent']),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    policy_mgr_url = module.params['policy_mgr_url']
+    policy = module.params['policy']
+    state = module.params['state'] or 'present'
+
+    # Ranger Admin does not expect "state" key
+    if "state" in policy:
+        del policy['state']
+
+    try:
+        name = policy['name']
+    except KeyError:
+        module.fail_json(msg='"name" is required in policy dict')
+    try:
+        service = policy['service']
+    except KeyError:
+        module.fail_json(msg='"service" is required in policy dict')
+
+    name_urlquote = urlquote(name)
+    service_urlquote = urlquote(service)
+    ranger_url_get_policy = '{}/service/public/v2/api/service/{}/policy/{}'.format(policy_mgr_url, service_urlquote, name_urlquote)
+    ranger_url_put_policy = ranger_url_get_policy
+    ranger_url_post_policy = '{}/service/public/v2/api/policy'.format(policy_mgr_url)
+    ranger_url_delete_policy = '{}/service/public/v2/api/policy?servicename={}&policyname={}'.format(policy_mgr_url, service_urlquote, name_urlquote)
+    headers = {
+        'Accept': 'application/json',
+    }
+    post_put_headers = {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+    }
+
+    try:
+        results = {
+            'changed': False,
+        }
+
+        get_resp, get_info = fetch_url(module, ranger_url_get_policy, headers=headers, method='GET')
+        get_status_code = get_info["status"]
+        if get_status_code != 200 and get_status_code != 404:
+            module.fail_json(msg='Error when getting Ranger policy "{}" in service "{}" with URL "{}", status code "{}"'.format(name, service, ranger_url_get_policy, get_status_code))
+
+        # Case when policy is absent
+        if get_status_code == 404:
+            # Case when policy is absent and must be removed -> nothing to do
+            if state == 'absent':
+                return module.exit_json(**results)
+            
+            # Case when policy is absent and must be created
+            results['changed'] = True
+            if not module.check_mode:
+                post_resp, post_info = fetch_url(module, ranger_url_post_policy, headers=post_put_headers, method='POST', data=json.dumps(policy))
+                post_status_code = post_info['status']
+                if post_status_code != 200:
+                    module.fail_json(msg='Error when creating Ranger policy "{}" in service "{}" with URL "{}", status code "{}"'.format(name, service, ranger_url_post_policy, post_status_code))
+
+        # Case when policy exists
+        else:
+            current_policy = json.load(get_resp)
+            dict_del_key(policy, current_policy)
+
+            # Case when policy exists and must be removed
+            if state == 'absent':
+                results['changed'] = True
+                if not module.check_mode:
+                    delete_resp, delete_info = fetch_url(module, ranger_url_delete_policy, headers=headers, method='DELETE')
+                    delete_status_code = delete_info['status']
+                    if delete_status_code != 204:
+                        module.fail_json(msg='Error when deleting Ranger policy "{}" in service "{}" with URL "{}", status code "{}"'.format(name, service, ranger_url_delete_policy, delete_status_code))
+
+            # Case when policy exists and must be present -> compare with current policy if an update is needed
+            elif not ranger_json_deep_equal(policy, current_policy):
+                results['changed'] = True
+                if module._diff:
+                    diff = results.setdefault('diff', {})
+                    diff['before'] = json.dumps(current_policy, sort_keys=True, indent=4) + '\n'
+                    diff['after'] = json.dumps(policy, sort_keys=True, indent=4) + '\n'
+                if not module.check_mode:
+                    put_resp, put_info = fetch_url(module, ranger_url_put_policy, headers=post_put_headers, method='PUT', data=json.dumps(policy))
+                    put_status_code = put_info['status']
+                    if put_status_code != 200:
+                        module.fail_json(msg='Error when updating Ranger policy "{}" in service "{}" with URL "{}", status code "{}"'.format(name, service, ranger_url_put_policy, put_status_code))
+
+        module.exit_json(**results)
+
+    except Exception:
+        import traceback
+        module.fail_json(msg=to_native(traceback.format_exc()))
+
+if __name__ == '__main__':
+    main()

--- a/roles/utils/ranger_policies/defaults/main.yml
+++ b/roles/utils/ranger_policies/defaults/main.yml
@@ -1,0 +1,29 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+ranger_policies: []
+  # # HDFS policy
+  # - name: policy_name_1
+  #   description: policy description
+  #   service: hdfs-tdp
+  #   isAuditEnabled: true
+  #   isEnabled: true
+  #   resources:
+  #     path:
+  #       isExcludes: false
+  #       isRecursive: true
+  #       values: ["/foo"]
+  #   policyItems:
+  #     - accesses:
+  #         - { isAllowed: true, type: read }
+  #         - { isAllowed: true, type: write }
+  #         - { isAllowed: true, type: execute }
+  #       conditions: []
+  #       delegateAdmin: true
+  #       groups: []
+  #       users: [tdp_user]
+  # # Delete policy
+  # - name: policy_name_2
+  #   service: hdfs-tdp
+  #   state: absent

--- a/roles/utils/ranger_policies/tasks/main.yml
+++ b/roles/utils/ranger_policies/tasks/main.yml
@@ -1,0 +1,18 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Configure Ranger Admin policies
+  tosit.tdp.ranger_policy:
+    policy_mgr_url: "https://{{ groups['ranger_admin'][0] | tosit.tdp.access_fqdn(hostvars) }}:6182"
+    policy: "{{ item }}"
+    state: "{{ item.state | default(omit) }}"
+    url_username: admin
+    url_password: "{{ ranger_admin_password }}"
+    force_basic_auth: yes
+  loop: "{{ ranger_policies }}"
+  loop_control:
+    label:
+      name: "{{ item.name | default('missing name') }}"
+      service: "{{ item.service | default('missing service') }}"
+      state: "{{ item.state | default('present') }}"


### PR DESCRIPTION
<!--  Thank you for sending a pull request! Please make sure:

1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes:
<!--
Example: "Fixes #(issue number)" or "Fixes (link of issue)".
-->
Fixes #443 

#### Additional comments:
<!--
Example: `"I was not sure if it is the right way to do but..."
-->

Variable example:
```yaml
ranger_policies:
  - name: tdp_user - path
    description: tdp_user access to /user/tdp_user
    service: hdfs-tdp
    isAuditEnabled: true
    isEnabled: true
    resources:
      path:
        isExcludes: false
        isRecursive: true
        values: ["/user/tdp_user"]
    policyItems:
      - accesses:
          - { isAllowed: true, type: read }
          - { isAllowed: true, type: write }
          - { isAllowed: true, type: execute }
        conditions: []
        delegateAdmin: true
        groups: []
        users: [tdp_user]
```

Ansible output:
```
TASK [tosit.tdp.ranger_policies : Configure Ranger Admin policies] ********************************
changed: [edge-01] => (item={'name': 'tdp_user - path', 'service': 'hdfs-tdp', 'state': 'present'})
```

Update variable (remove execute permission):
```yaml
ranger_policies:
  - name: tdp_user - path
    description: tdp_user access to /user/tdp_user
    service: hdfs-tdp
    isAuditEnabled: true
    isEnabled: true
    resources:
      path:
        isExcludes: false
        isRecursive: true
        values: ["/user/tdp_user"]
    policyItems:
      - accesses:
          - { isAllowed: true, type: read }
          - { isAllowed: true, type: write }
        conditions: []
        delegateAdmin: true
        groups: []
        users: [tdp_user]
```

Ansible output with `--diff` (you can preview the diff by running with `--check` and the diff will be displayed without updating policy):
```
TASK [tosit.tdp.ranger_policies : Configure Ranger Admin policies] ********************************
--- before
+++ after
@@ -13,10 +13,6 @@
                 {
                     "isAllowed": true, 
                     "type": "write"
-                }, 
-                {
-                    "isAllowed": true, 
-                    "type": "execute"
                 }
             ], 
             "conditions": [], 

changed: [edge-01] => (item={'name': 'tdp_user - path', 'service': 'hdfs-tdp', 'state': 'present'})
```

Update variable (delete policy):
```yaml
ranger_policies:
  - name: tdp_user - path
    service: hdfs-tdp
    state: absent
```

Ansible output:
```
TASK [tosit.tdp.ranger_policies : Configure Ranger Admin policies] ********************************
changed: [edge-01] => (item={'name': 'tdp_user - path', 'service': 'hdfs-tdp', 'state': 'absent'})
```

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to [TOSIT](https://www.tosit.io/),
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.

