### PR TITLE
fix(ranger): remove install.properties task duplicate

### DIFF
--- a/roles/ranger/admin/tasks/config.yml
+++ b/roles/ranger/admin/tasks/config.yml
@@ -7,11 +7,6 @@
     src: install.properties.j2
     dest: "{{ ranger_install_dir }}/install.properties"
 
-- name: Template install.properties
-  template:
-    src: install.properties.j2
-    dest: "{{ ranger_install_dir }}/install.properties"
-
 - name: Run setup.sh
   shell: |
     export JAVA_HOME=/usr/lib/jvm/jre-1.8.0-openjdk


### PR DESCRIPTION
<!--  Thank you for sending a pull request! Please make sure:

1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes:
<!--
Example: "Fixes #(issue number)" or "Fixes (link of issue)".
-->
Fixes #445 

#### Additional comments:
<!--
Example: `"I was not sure if it is the right way to do but..."
-->
The Ranger Admin install.properties file was rendered twice in a row. I removed the duplicate.

---
To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to [TOSIT](https://www.tosit.io/),
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.

