### PR TITLE
fix(hbase): regionserver core-site + hdfs-site from hadoop client conf

### DIFF
--- a/roles/hbase/regionserver/tasks/config.yml
+++ b/roles/hbase/regionserver/tasks/config.yml
@@ -29,13 +29,13 @@
 
 - name: Copy core-site.xml
   copy:
-    src: /etc/hadoop/conf.dn/core-site.xml
+    src: '{{ hadoop_client_conf_dir }}/core-site.xml'
     dest: '{{ hbase_rs_conf_dir }}/core-site.xml'
     remote_src: yes
 
 - name: Copy hdfs-site.xml
   copy:
-    src: /etc/hadoop/conf.dn/hdfs-site.xml
+    src: '{{ hadoop_client_conf_dir }}/hdfs-site.xml'
     dest: '{{ hbase_rs_conf_dir }}/hdfs-site.xml'
     remote_src: yes
 

--- a/tdp_lib_dag/hbase.yml
+++ b/tdp_lib_dag/hbase.yml
@@ -81,6 +81,7 @@
 
 - name: hbase_regionserver_config
   depends_on:
+    - hadoop_client_config
     - hdfs_client_config
     - yarn_client_config
     - hbase_kerberos_install


### PR DESCRIPTION
<!--  Thank you for sending a pull request! Please make sure:

1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes:
<!--
Example: "Fixes #(issue number)" or "Fixes (link of issue)".
-->
Fixes #450 

#### Additional comments:
<!--
Example: `"I was not sure if it is the right way to do but..."
-->
HBase regionserver won't depend on HDFS Data Node installation anymore, and we'll get rid of 2 hard coded paths.
DAG : `hbase_regionserver_config` now depends on `hadoop_client_config`
After this, I'm finally able to install Hbase without having a local HDFS installation. 👍 

---
To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to [TOSIT](https://www.tosit.io/),
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.

