### PR TITLE
rangerkms: fix setup.sh failure for schema setup

### DIFF
--- a/roles/ranger/kms/tasks/config.yml
+++ b/roles/ranger/kms/tasks/config.yml
@@ -13,6 +13,7 @@
     ./setup.sh
   args:
     chdir: '{{ ranger_kms_install_dir }}'
+  throttle: 1
 
 - name: Create symbolic link to configuration directory
   file:


### PR DESCRIPTION
<!--  Thank you for sending a pull request! Please make sure:

1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes:
<!--
Example: "Fixes #(issue number)" or "Fixes (link of issue)".
-->
Fixes #492

Use ```throttle: 1``` put in the ```setup.sh``` running task to avoid parallel execution of the task.

#### Additional comments:
<!--
Example: `"I was not sure if it is the right way to do but..."
-->

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to [TOSIT](https://www.tosit.io/),
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.

