### PR TITLE
fix(hdfs): hardcoded namenode config dir in hdfs ranger config

### DIFF
--- a/roles/hdfs/ranger/tasks/config.yml
+++ b/roles/hdfs/ranger/tasks/config.yml
@@ -27,7 +27,7 @@
   lineinfile:
     path: "{{ ranger_hdfs_install_dir }}/install/conf.templates/enable/ranger-hdfs-security-changes.cfg"
     regexp: '^ranger.plugin.hdfs.policy.rest.ssl.config.file\s+([^ ]+) (.*)$'
-    line: 'ranger.plugin.hdfs.policy.rest.ssl.config.file    /etc/hadoop/conf.nn/ranger-policymgr-ssl.xml \2'
+    line: 'ranger.plugin.hdfs.policy.rest.ssl.config.file    {{ hadoop_nn_conf_dir }}/ranger-policymgr-ssl.xml \2'
     backrefs: yes
 
 - name: Run enable-hdfs-plugin.sh


### PR DESCRIPTION
<!--  Thank you for sending a pull request! Please make sure:

1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes:
<!--
Example: "Fixes #(issue number)" or "Fixes (link of issue)".
-->
Fixes #434

#### Additional comments:
<!--
Example: `"I was not sure if it is the right way to do but..."
-->

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to [TOSIT](https://www.tosit.io/),
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.

