### PR TITLE
fix(kms): render auth to local rule in kms-site

### DIFF
--- a/roles/ranger/common/templates/kms-site.xml.j2
+++ b/roles/ranger/common/templates/kms-site.xml.j2
@@ -108,16 +108,7 @@
   <property>
     <name>hadoop.kms.authentication.kerberos.name.rules</name>
 
-    <value>RULE:[2:$1/$2@$0]([ndj]n/.*@{{ realm }})s/.*/hdfs/
-RULE:[2:$1/$2@$0]([rn]m/.*@{{ realm }})s/.*/yarn/
-RULE:[2:$1/$2@$0](jhs/.*@{{ realm }})s/.*/mapred/
-RULE:[2:$1/$2@$0](hive/.*@{{ realm }})s/.*/hive/
-RULE:[2:$1/$2@$0](HTTP/.*@{{ realm }})s/.*/HTTP/
-RULE:[2:$1/$2@$0](knox/.*@{{ realm }})s/.*/knox/
-RULE:[2:$1/$2@$0](rangeradmin/.*@{{ realm }})s/.*/rangeradmin/
-RULE:[2:$1/$2@$0](keyadmin/.*@{{ realm }})s/.*/keyadmin/
-DEFAULT
-</value>
+    <value>{{ core_site['hadoop.security.auth_to_local'] }}</value>
     <description>
       Rules used to resolve Kerberos principal names.
     </description>

--- a/tdp_vars_defaults/hadoop/hadoop.yml
+++ b/tdp_vars_defaults/hadoop/hadoop.yml
@@ -125,6 +125,10 @@ auth_to_local:
     - RULE:[1:$1@$0]({{ zookeeper_headless_principal }}@{{ realm }})s/.*/zookeeper/
   spark:
     - RULE:[1:$1@$0]({{ spark_headless_principal }}@{{ realm }})s/.*/spark/
+  ranger:
+    - RULE:[2:$1/$2@$0](rangeradmin/.*@{{ realm }})s/.*/rangeradmin/
+    - RULE:[2:$1/$2@$0](keyadmin/.*@{{ realm }})s/.*/keyadmin/
+
 
 # Rack awareness
 rack_prefix: default


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #552

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

After investigation, the error is due to bad auth_to_local rules in kms-site.

This PR renders the same auth_to_local as the one in core-site. With this fix, I don't have the exception anymore.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
