### PR TITLE
feat: add pre-commit with ansible-lint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .vscode/
 /files/
 playbooks/files
+venv
 
 *.tar.gz
 *.pyc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+- repo: https://github.com/ansible/ansible-lint.git
+  rev: v5.4.0
+  hooks:
+    - id: ansible-lint

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -1,0 +1,3 @@
+ansible==2.9.27
+ansible-lint==5.4.0
+pre-commit==2.20.0

--- a/dev/setup.sh
+++ b/dev/setup.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly PYTHON_BIN=${PYTHON_BIN:-python3}
+readonly PYTHON_VENV=${PYTHON_VENV:-venv}
+
+setup_python_venv() {
+  if [[ ! -d "$PYTHON_VENV" ]]; then
+    echo "Create python venv with '${PYTHON_BIN}' to '${PYTHON_VENV}' and update pip to latest version"
+    "$PYTHON_BIN" -m venv "$PYTHON_VENV"
+    (
+      source "${PYTHON_VENV}/bin/activate"
+      pip install -U pip
+    )
+  else
+    echo "Python venv '${PYTHON_VENV}' already exists, nothing to do"
+  fi
+  echo "Install python dependencies"
+  (
+    source "${PYTHON_VENV}/bin/activate"
+    pip install -r dev/requirements.txt
+    pre-commit install
+  )
+  return 0
+}
+
+main() {
+  setup_python_venv
+}
+
+main "$@"


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #468 

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

I created as draft because I am struggling to understand the behavior of `ansible-lint`.

I left on purpose an unnamed `block` task at `roles/hbase/phoenix/queryserver/daemon/tasks/kerberos.yml#L10` to explain.

Running `ansible-lint roles` (inside the venv) gives:

```
ARNING  The following filters were mocked during the run: Invalid plugin FQCN (tosit.tdp.access_fqdn): unable to locate collection tosit.tdp
You can skip specific rules or tags by adding them to your configuration file:
# .config/ansible-lint.yml
warn_list:  # or 'skip_list' to silence them completely
  - experimental  # all rules tagged as experimental
  - name[missing]  # Rule for checking task and play names.

                              Rule Violation Summary                              
 count tag                       profile rule associated tags                     
    18 command-instead-of-shell  basic   command-shell, idiom (warning)           
     1 deprecated-command-syntax basic   command-shell, deprecations (warning)    
    26 key-order[task]           basic   formatting, experimental (warning)       
     1 name[missing]             basic   idiom                                    
     2 yaml[comments]            basic   formatting, yaml (warning)               
     3 yaml[indentation]         basic   formatting, yaml (warning)               
     7 yaml[line-length]         basic   formatting, yaml (warning)               
     3 risky-file-permissions    safety  unpredictability, experimental (warning) 
     5 risky-shell-pipe          safety  command-shell (warning)                  
     1 ignore-errors             shared  unpredictability, experimental (warning) 
    10 no-changed-when           shared  command-shell, idempotency (warning)     

Failed after min profile: 1 failure(s), 76 warning(s) on 400 files.
```

Whereas running just `ansible-lint` gives no failures:

```
WARNING  Replaced outdated tag 'unnamed-task' with 'name[missing]', replace it to avoid future regressions

Passed with production profile: 0 failure(s), 0 warning(s) on 680 files.
```

The issue is that the pre-commit hook for ansible-lint runs `python3 -m ansiblelint -vv --force-color` so in this case the task naming error is not catched for example.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
