### PR TITLE
feat(ranger-kms): make kms-site additionnal properties configurable

### DIFF
--- a/roles/ranger/common/templates/kms-site.xml.j2
+++ b/roles/ranger/common/templates/kms-site.xml.j2
@@ -170,115 +170,16 @@
       The Kerberos service principal used to connect to Zookeeper.
     </description>
   </property>
-  
-  <property>
-  	<name>hadoop.kms.security.authorization.manager</name>
-  	<value>org.apache.ranger.authorization.kms.authorizer.RangerKmsAuthorizer</value>
-  </property>
-  
-  <property>
-  	<name>hadoop.kms.proxyuser.rangeradmin.groups</name>
-  	<value>*</value>
-  </property>
-  
-  <property>
-  	<name>hadoop.kms.proxyuser.rangeradmin.hosts</name>
-  	<value>*</value>
-  </property>
-  
-  <property>
-  	<name>hadoop.kms.proxyuser.rangeradmin.users</name>
-  	<value>*</value>
-  </property>
 
   <property>
-  	<name>hadoop.kms.proxyuser.hdfs.groups</name>
-  	<value>*</value>
-  </property>
-  
-  <property>
-  	<name>hadoop.kms.proxyuser.hdfs.hosts</name>
-  	<value>*</value>
-  </property>
-  
-  <property>
-  	<name>hadoop.kms.proxyuser.hdfs.users</name>
-  	<value>*</value>
+    <name>hadoop.kms.security.authorization.manager</name>
+    <value>org.apache.ranger.authorization.kms.authorizer.RangerKmsAuthorizer</value>
   </property>
 
+{% for name, value in kms_site.items() %}
   <property>
-  	<name>hadoop.kms.proxyuser.HTTP.groups</name>
-  	<value>*</value>
+    <name>{{ name }}</name>
+    <value>{{ value }}</value>
   </property>
-  
-  <property>
-  	<name>hadoop.kms.proxyuser.HTTP.hosts</name>
-  	<value>*</value>
-  </property>
-  
-  <property>
-  	<name>hadoop.kms.proxyuser.HTTP.users</name>
-  	<value>*</value>
-  </property>
-
-  <property>
-  	<name>hadoop.kms.proxyuser.knox.groups</name>
-  	<value>*</value>
-  </property>
-  
-  <property>
-  	<name>hadoop.kms.proxyuser.knox.hosts</name>
-  	<value>*</value>
-  </property>
-  
-  <property>
-  	<name>hadoop.kms.proxyuser.knox.users</name>
-  	<value>*</value>
-  </property>
-
-  <property>
-  	<name>hadoop.kms.proxyuser.keyadmin.groups</name>
-  	<value>*</value>
-  </property>
-  
-  <property>
-  	<name>hadoop.kms.proxyuser.keyadmin.hosts</name>
-  	<value>*</value>
-  </property>
-  
-  <property>
-  	<name>hadoop.kms.proxyuser.keyadmin.users</name>
-  	<value>*</value>
-  </property>
-
-  <property>
-  	<name>hadoop.kms.proxyuser.yarn.groups</name>
-  	<value>*</value>
-  </property>
-  
-  <property>
-  	<name>hadoop.kms.proxyuser.yarn.hosts</name>
-  	<value>*</value>
-  </property>
-  
-  <property>
-  	<name>hadoop.kms.proxyuser.yarn.users</name>
-  	<value>*</value>
-  </property>
-
-  <property>
-  	<name>hadoop.kms.proxyuser.hive.groups</name>
-  	<value>*</value>
-  </property>
-  
-  <property>
-  	<name>hadoop.kms.proxyuser.hive.hosts</name>
-  	<value>*</value>
-  </property>
-  
-  <property>
-  	<name>hadoop.kms.proxyuser.hive.users</name>
-  	<value>*</value>
-  </property>
-
+{% endfor %}
 </configuration>

--- a/tdp_vars_defaults/ranger/ranger_kms.yml
+++ b/tdp_vars_defaults/ranger/ranger_kms.yml
@@ -1,0 +1,20 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+# kms-site.xml additional properties
+kms_site:
+  hadoop.kms.proxyuser.rangeradmin.groups: '*'
+  hadoop.kms.proxyuser.rangeradmin.hosts: '*'
+  hadoop.kms.proxyuser.hdfs.groups: '*'
+  hadoop.kms.proxyuser.hdfs.hosts: '*'
+  hadoop.kms.proxyuser.HTTP.groups: '*'
+  hadoop.kms.proxyuser.HTTP.hosts: '*'
+  hadoop.kms.proxyuser.knox.groups: '*'
+  hadoop.kms.proxyuser.knox.hosts: '*'
+  hadoop.kms.proxyuser.keyadmin.groups: '*'
+  hadoop.kms.proxyuser.keyadmin.hosts: '*'
+  hadoop.kms.proxyuser.yarn.groups: '*'
+  hadoop.kms.proxyuser.yarn.hosts: '*'
+  hadoop.kms.proxyuser.hive.groups: '*'
+  hadoop.kms.proxyuser.hive.hosts: '*'


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #564

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

This PR makes it possible to add properties to `kms-site.xml`.

I removed the `hadoop.kms.proxyuser.*.users` since we do template them for the hadoop core-site.


#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
