### PR TITLE
fix: default to empty list of hosts in topology

### DIFF
--- a/tdp_vars_defaults/knox/knox.yml
+++ b/tdp_vars_defaults/knox/knox.yml
@@ -105,43 +105,43 @@ gateway_topology:
         name: Default
     services:
       NAMENODE:
-        hosts: "{{ groups['hdfs_nn'] | map('tosit.tdp.access_fqdn', hostvars) | list }}"
+        hosts: "{{ groups['hdfs_nn'] | default([]) | map('tosit.tdp.access_fqdn', hostvars) | list }}"
         port: "{{ hdfs_nn_rpc_port }}"
         scheme: hdfs://
       HDFSUI:
-        hosts: "{{ groups['hdfs_nn'] | map('tosit.tdp.access_fqdn', hostvars) | list }}"
+        hosts: "{{ groups['hdfs_nn'] | default([]) | map('tosit.tdp.access_fqdn', hostvars) | list }}"
         port: "{{ hdfs_nn_https_port }}"
         version: 2.7.0
       JOBHISTORYUI:
         hosts:
-          - "{{ groups['mapred_jhs'] | map('tosit.tdp.access_fqdn', hostvars) | first }}"
+          - "{{ groups['mapred_jhs'] | default([]) | map('tosit.tdp.access_fqdn', hostvars) | first }}"
         port: "{{ mapred_jhs_https_port }}"
       HIVE: {}
       RANGERUI:
-        hosts: "{{ groups['ranger_admin'] | map('tosit.tdp.access_fqdn', hostvars) | list }}"
+        hosts: "{{ groups['ranger_admin'] | default([]) | map('tosit.tdp.access_fqdn', hostvars) | list }}"
         port: "{{ ranger_adm_https_port }}"
       RESOURCEMANAGER:
-        hosts: "{{ groups['yarn_rm'] | map('tosit.tdp.access_fqdn', hostvars) | list }}"
+        hosts: "{{ groups['yarn_rm'] | default([]) | map('tosit.tdp.access_fqdn', hostvars) | list }}"
         location: /ws
         port: "{{ yarn_rm_https_port }}"
       SPARKHISTORYUI:
-        hosts: "{{ groups['spark_hs'] | map('tosit.tdp.access_fqdn', hostvars) | list }}"
+        hosts: "{{ groups['spark_hs'] | default([]) | map('tosit.tdp.access_fqdn', hostvars) | list }}"
         port: "{{ spark_hs_https_port }}"
       SPARK3HISTORYUI:
-        hosts: "{{ groups['spark3_hs'] | map('tosit.tdp.access_fqdn', hostvars) | list }}"
+        hosts: "{{ groups['spark3_hs'] | default([]) | map('tosit.tdp.access_fqdn', hostvars) | list }}"
         port: "{{ spark3_hs_https_port}}"
       WEBHBASE:
-        hosts: "{{ groups['hbase_rest'] | map('tosit.tdp.access_fqdn', hostvars) | list }}"
+        hosts: "{{ groups['hbase_rest'] | default([]) | map('tosit.tdp.access_fqdn', hostvars) | list }}"
         port: "{{ hbase_rest_https_port }}"
       WEBHDFS:
-        hosts: "{{ groups['hdfs_nn'] | map('tosit.tdp.access_fqdn', hostvars) | list }}"
+        hosts: "{{ groups['hdfs_nn'] | default([]) | map('tosit.tdp.access_fqdn', hostvars) | list }}"
         location: /webhdfs
         port: "{{ hdfs_nn_https_port }}"
       YARNUI:
-        hosts: "{{ groups['yarn_rm'] | map('tosit.tdp.access_fqdn', hostvars) | list }}"
+        hosts: "{{ groups['yarn_rm'] | default([]) | map('tosit.tdp.access_fqdn', hostvars) | list }}"
         port: "{{ yarn_rm_https_port }}"
       HBASEUI:
-        hosts: "{{ groups['hbase_master'] | map('tosit.tdp.access_fqdn', hostvars) | list }}"
+        hosts: "{{ groups['hbase_master'] | default([]) | map('tosit.tdp.access_fqdn', hostvars) | list }}"
         port: "{{ hbase_master_info_https_port }}"
 
 # Service start on boot policies


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #586 

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

I am not really happy with the result as Knox will still create the endpoint that will end up with:
![image](https://user-images.githubusercontent.com/11584800/207390378-6bec41e3-6f64-4804-9fe5-8d84476e0be2.png)

But I don't see how to solve this without making the configuration super verbose with dynamic dict generation.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
