### PR TITLE
tests: add test engine

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,163 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+This will autogenerate a list of tests depending on the input document.
+The values that can be `service` or `service_component` will be referred as a service_component in
+the following code for simplicity.
+"""
+
+import os
+import json
+from pathlib import Path
+
+import pytest
+
+from tdp.core.collection import Collection
+from tdp.core.collections import Collections
+from tdp.core.dag import Dag
+from tdp.core.deployment import DeploymentPlan
+from tdp.core.variables import ClusterVariables
+
+TEST_DIR = os.path.dirname(__file__)
+DEFAULT_RULES_PATH = os.path.join(TEST_DIR, "rules.json")
+DEFAULT_COLLECTION_PATH = os.path.dirname(TEST_DIR)
+
+PARAMETERS_AS_FIXTURES = frozenset({"must_include", "must_exclude"})
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--rules",
+        dest="rules",
+        default=DEFAULT_RULES_PATH,
+        type=Path,
+        help="rules file path",
+    )
+    parser.addoption(
+        "--collections-path",
+        dest="collections_path",
+        default=DEFAULT_COLLECTION_PATH,
+        type=str,
+        help=f"collections path (separated by {os.pathsep})",
+    )
+
+
+def parse_rules(rules_path):
+    with rules_path.open() as fd:
+        return json.load(fd)
+
+
+def pytest_generate_tests(metafunc):
+    rules = parse_rules(metafunc.config.getoption("rules"))
+    parameters = {"service_component"}.union(PARAMETERS_AS_FIXTURES)
+    idlist = []
+    # get only fixtures used in the test, ensure service_component is the first
+    argnames = sorted(
+        parameters.intersection(metafunc.fixturenames),
+        key=lambda param: 0 if param == "service_component" else 1,
+    )
+    argvalues = []  # list of every set of parameters to give to the test
+    for service_component, rule in rules.items():
+        # One iteration is a set of parameters to give to a test
+        iteration_argvalues = []
+        for fixture in argnames:
+            if fixture == "service_component":
+                iteration_argvalues.append(service_component)
+            else:
+                iteration_argvalues.append(frozenset(rule.get(fixture, frozenset())))
+        # Will not add the value if only component is not null
+        # therefore the test will not be generated
+        if argnames[0] == "service_component":
+            # if a test as the fixture `service_component`, we will generate it
+            # only if any of the parameters from the rules is non null
+            # the nullity check must be performed on every iteration_argalues
+            # except `service_component`
+            iteration_argvalues_to_test = iteration_argvalues[1:]
+        else:
+            # If the fixture `service_component` is missing,
+            # the nullity check must be performed on the iteration_argvalues
+            iteration_argvalues_to_test = iteration_argvalues
+
+        if any(iteration_argvalues_to_test):
+            # if any parameter for this iteration is not null
+            # we add these operations to the parameter list
+            idlist.append(service_component)
+            argvalues.append(iteration_argvalues)
+
+    metafunc.parametrize(argnames, argvalues, ids=idlist, scope="session")
+
+
+@pytest.fixture(scope="session")
+def collection_list(request):
+    collections_path = request.config.getoption("collections_path")
+    return [Collection.from_path(split) for split in collections_path.split(os.pathsep)]
+
+
+@pytest.fixture(scope="session")
+def collections(collection_list):
+    return Collections.from_collection_list(collection_list)
+
+
+@pytest.fixture(scope="session")
+def dag(collections: Collections):
+    return Dag(collections)
+
+
+@pytest.fixture(scope="session")
+def cluster_variables(collections, tmp_path_factory):
+    return ClusterVariables.initialize_cluster_variables(
+        collections,
+        tmp_path_factory.mktemp("tdp_vars"),
+    )
+
+
+@pytest.fixture(scope="session")
+def deployment_plan(service_component, cluster_variables, dag):
+    """Generates one reconfigure deployment plan for each service_component for the whole session"""
+    service = service_component.split("_")[0]
+
+    service_component_versions = ((service, service_component, 1),)
+
+    component_modified = getattr(cluster_variables[service], "components_modified")
+
+    def mock_components_modified(dag, version):
+        """If the service_component is a service,
+        instead returns the list of every component from the service
+        """
+        try:
+            operation = dag.operations[service_component + "_config"]
+        except KeyError:
+            pytest.fail(
+                f"{service_component} does not exists or does not have a config action"
+            )
+        if operation.is_service():
+            service_operations = dag.services_operations[operation.service]
+            return list(
+                filter(
+                    lambda operation: operation.action == "config",
+                    service_operations,
+                )
+            )
+        return [operation]
+
+    setattr(cluster_variables[service], "components_modified", mock_components_modified)
+    try:
+        return DeploymentPlan.from_reconfigure(
+            dag, cluster_variables, service_component_versions
+        )
+    finally:
+        setattr(cluster_variables[service], "components_modified", component_modified)
+
+
+@pytest.fixture(scope="session")
+def deployment_service_components(deployment_plan):
+    """Converts list of operations into a list of `service_component` for ease of testing"""
+    operations = []
+    for operation in deployment_plan.operations:
+        name = operation.service
+        if operation.component is not None:
+            name += "_" + operation.component
+        if not name in operations:
+            operations.append(name)
+    return operations

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+minversion = 6.0
+addopts = -r=A --show-capture=no

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,2 @@
+pytest==6
+git+https://github.com/TOSIT-IO/tdp-lib@e6c875d#egg=tdp-lib

--- a/tests/rules.json
+++ b/tests/rules.json
@@ -1,0 +1,50 @@
+{
+  "tdp-cluster": {
+    "must_include": [
+        "exporter",
+        "hadoop",
+        "hbase",
+        "hdfs",
+        "hive",
+        "knox",
+        "ranger",
+        "spark3",
+        "spark",
+        "tdp-cluster",
+        "yarn",
+        "zookeeper"
+    ]
+  },
+  "hdfs": {
+    "must_include": ["yarn"],
+    "must_exclude": ["zookeeper"]
+  },
+  "yarn": {
+    "must_include": ["hive"],
+    "must_exclude": ["hdfs"]
+  },
+  "yarn_client": {
+    "must_include": ["hive"],
+    "must_exclude": ["hdfs"]
+  },
+  "yarn_apptimelineserver": {
+    "must_include": ["hive"],
+    "must_exclude": ["hdfs"]
+  },
+  "yarn_nodemanager": {
+    "must_include": ["hive"],
+    "must_exclude": ["hdfs"]
+  },
+  "yarn_resourcemanager": {
+    "must_include": ["hive"],
+    "must_exclude": ["hdfs"]
+  },
+  "hdfs_client": {
+    "must_include": ["hdfs", "hbase", "yarn"],
+    "must_exclude": ["hdfs_namenode", "hdfs_datanode", "zookeeper"]
+  },
+  "hbase": {
+    "must_include": ["spark3"]
+  },
+  "hdfs_no_test_generated_because_empty_dict": {}
+}

--- a/tests/test_reconfigure.py
+++ b/tests/test_reconfigure.py
@@ -1,0 +1,26 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+def test_must_include_and_must_exclude_should_not_intersect(must_include: set, must_exclude: set):
+    intersection = must_include.intersection(must_exclude)
+    assert (
+        intersection == set()
+    ), f"must_include and must_exclude should not intersect: {', '.join(intersection)}"
+
+
+def test_reconfigure_plan_has_included_services(
+    service_component: str, must_include: set, deployment_service_components :list
+):
+    difference = must_include.difference(deployment_service_components)
+    assert (
+        len(difference) == 0
+    ), f"{service_component} reconfiguration should include: {', '.join(difference)}"
+
+
+def test_reconfigure_plan_does_not_have_excluded_services(
+    service_component: str, must_exclude: set, deployment_service_components: set
+):
+    intersection = must_exclude.intersection(deployment_service_components)
+    assert (
+        len(intersection) == 0
+    ), f"{service_component} reconfiguration should exclude: {', '.join(intersection)}"


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes TOSIT-IO/tdp-lib#299

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

This PR introduces a test engine able to parse rules and generate tests accordingly.

Tests are defined by a dict, with a key being either a service or a component, and with values defining services or component that must be reconfigured or not.

example
```json
{
  "hdfs": {
    "must_include": ["yarn"],
    "must_exclude": ["zookeeper"]
  }
}
```


Tests output:
```bash
py.test tests
==================================================================================================================== test session starts =====================================================================================================================
platform linux -- Python 3.6.15, pytest-6.0.0, py-1.11.0, pluggy-0.13.1
rootdir: /home/gboutry/Documents/projects/tdp-getting-started/ansible_collections/tosit/tdp/tests, configfile: pytest.ini
collected 25 items                                                                                                                                                                                                                                           

tests/test_reconfigure.py ..F......................                                                                                                                                                                                                    [100%]

========================================================================================================================== FAILURES ==========================================================================================================================
__________________________________________________________________________________________________ test_reconfigure_plan_has_included_services[tdp-cluster] __________________________________________________________________________________________________

service_component = 'tdp-cluster', must_include = frozenset({'exporter', 'hadoop', 'hbase', 'hdfs', 'hive', 'knox', ...})
deployment_service_components = ['tdp-cluster', 'zookeeper_client', 'zookeeper_jmx-exporter', 'zookeeper_server', 'zookeeper', 'hadoop_client', ...]

    def test_reconfigure_plan_has_included_services(
        service_component: str, must_include: set, deployment_service_components :list
    ):
        difference = must_include.difference(deployment_service_components)
>       assert (
            len(difference) == 0
        ), f"{service_component} reconfiguration should include: {', '.join(difference)}"
E       AssertionError: tdp-cluster reconfiguration should include: exporter
E       assert 1 == 0
E        +  where 1 = len(frozenset({'exporter'}))

tests/test_reconfigure.py:12: AssertionError
=========================================================================================================================== PASSES ===========================================================================================================================
________________________________________________________________________________________________ test_reconfigure_plan_does_not_have_excluded_services[hdfs] _________________________________________________________________________________________________
================================================================================================================== short test summary info ===================================================================================================================
PASSED tests/test_reconfigure.py::test_must_include_and_must_exclude_should_not_intersect[tdp-cluster]
PASSED tests/test_reconfigure.py::test_reconfigure_plan_does_not_have_excluded_services[hdfs]
PASSED tests/test_reconfigure.py::test_must_include_and_must_exclude_should_not_intersect[hdfs]
PASSED tests/test_reconfigure.py::test_reconfigure_plan_does_not_have_excluded_services[yarn]
PASSED tests/test_reconfigure.py::test_reconfigure_plan_has_included_services[hdfs]
PASSED tests/test_reconfigure.py::test_must_include_and_must_exclude_should_not_intersect[yarn]
PASSED tests/test_reconfigure.py::test_reconfigure_plan_does_not_have_excluded_services[yarn_client]
PASSED tests/test_reconfigure.py::test_reconfigure_plan_has_included_services[yarn]
PASSED tests/test_reconfigure.py::test_must_include_and_must_exclude_should_not_intersect[yarn_client]
PASSED tests/test_reconfigure.py::test_reconfigure_plan_does_not_have_excluded_services[yarn_apptimelineserver]
PASSED tests/test_reconfigure.py::test_reconfigure_plan_has_included_services[yarn_client]
PASSED tests/test_reconfigure.py::test_must_include_and_must_exclude_should_not_intersect[yarn_apptimelineserver]
PASSED tests/test_reconfigure.py::test_reconfigure_plan_does_not_have_excluded_services[yarn_nodemanager]
PASSED tests/test_reconfigure.py::test_reconfigure_plan_has_included_services[yarn_apptimelineserver]
PASSED tests/test_reconfigure.py::test_must_include_and_must_exclude_should_not_intersect[yarn_nodemanager]
PASSED tests/test_reconfigure.py::test_reconfigure_plan_does_not_have_excluded_services[yarn_resourcemanager]
PASSED tests/test_reconfigure.py::test_reconfigure_plan_has_included_services[yarn_nodemanager]
PASSED tests/test_reconfigure.py::test_must_include_and_must_exclude_should_not_intersect[yarn_resourcemanager]
PASSED tests/test_reconfigure.py::test_reconfigure_plan_does_not_have_excluded_services[hdfs_client]
PASSED tests/test_reconfigure.py::test_reconfigure_plan_has_included_services[yarn_resourcemanager]
PASSED tests/test_reconfigure.py::test_must_include_and_must_exclude_should_not_intersect[hdfs_client]
PASSED tests/test_reconfigure.py::test_reconfigure_plan_has_included_services[hdfs_client]
PASSED tests/test_reconfigure.py::test_must_include_and_must_exclude_should_not_intersect[hbase]
PASSED tests/test_reconfigure.py::test_reconfigure_plan_has_included_services[hbase]
FAILED tests/test_reconfigure.py::test_reconfigure_plan_has_included_services[tdp-cluster] - AssertionError: tdp-cluster reconfiguration should include: exporter
================================================================================================================ 1 failed, 24 passed in 0.34s ================================================================================================================
```

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
