### PR TITLE
fix: change hardcoded knox conf dir

### DIFF
--- a/roles/knox/common/templates/knox-gateway.service.j2
+++ b/roles/knox/common/templates/knox-gateway.service.j2
@@ -9,7 +9,7 @@ User={{ knox_user }}
 Group={{ knox_group }}
 PIDFile={{ knox_pid_dir }}/gateway.pid
 Environment="ENV_PID_DIR={{ knox_pid_dir }}"
-ExecStart={{ knox_install_dir }}/bin/gateway.sh start --config /etc/knox/conf/ -Djavax.net.ssl.trustStrore={{ knox_keystore_dir }}/truststore.jks
+ExecStart={{ knox_install_dir }}/bin/gateway.sh start --config {{ knox_conf_dir }}
 ExecStop={{ knox_install_dir }}/bin/gateway.sh stop
 SuccessExitStatus=143
 LimitNOFILE=64000

--- a/tdp_vars_defaults/knox/knox.yml
+++ b/tdp_vars_defaults/knox/knox.yml
@@ -56,7 +56,6 @@ gateway_site:
   gateway.hadoop.kerberos.secured: "true"
   java.security.krb5.conf: /etc/krb5.conf
   java.security.auth.login.config: "{{ knox_conf_dir }}/krb5JAASLogin.conf"
-  sun.security.krb5.debug: "true"
   gateway.deployment.dir: "{{ knox_data_dir }}/data/deployments"
   gateway.security.dir: "{{ knox_data_dir }}/data/security"
   gateway.data.dir: "{{ knox_data_dir }}/data"


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #592 

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

I ended up removing the `javax.net.ssl.trustStore` since there was an syntax error, it was not probably useful anyway.

I also removed the `sun.debug.security.krb5.debug` property because it was spamming logs in `/var/log/knox/gateway.out`.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
