### PR TITLE
feat: add status tasks and playbooks

### DIFF
--- a/playbooks/exporter_node_status.yml
+++ b/playbooks/exporter_node_status.yml
@@ -1,0 +1,14 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: node-exporter status
+  hosts: exporter_node
+  tasks:
+    - tosit.tdp.resolve: # noqa unnamed-task
+        node_name: exporter_node
+    - name: node exporter status
+      import_role:
+        name: tosit.tdp.exporter.node
+        tasks_from: status
+    - meta: clear_facts # noqa unnamed-task

--- a/playbooks/hbase_master_status.yml
+++ b/playbooks/hbase_master_status.yml
@@ -1,0 +1,14 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: HBase Master status
+  hosts: hbase_master
+  tasks:
+    - tosit.tdp.resolve: # noqa unnamed-task
+        node_name: hbase_master
+    - name: HBase Master status
+      import_role:
+        name: tosit.tdp.hbase.master
+        tasks_from: status
+    - meta: clear_facts # noqa unnamed-task

--- a/playbooks/hbase_phoenix_queryserver_daemon_status.yml
+++ b/playbooks/hbase_phoenix_queryserver_daemon_status.yml
@@ -1,0 +1,14 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: HBase Phoenix QueryServer status
+  hosts: phoenix_queryserver_daemon
+  tasks:
+    - tosit.tdp.resolve: # noqa unnamed-task
+        node_name: hbase_phoenix_queryserver_daemon
+    - name: HBase Phoenix QueryServer Daemon status
+      import_role:
+        name: tosit.tdp.hbase.phoenix.queryserver.daemon
+        tasks_from: status
+    - meta: clear_facts # noqa unnamed-task

--- a/playbooks/hbase_regionserver_status.yml
+++ b/playbooks/hbase_regionserver_status.yml
@@ -1,0 +1,14 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: HBase RegionServer status
+  hosts: hbase_rs
+  tasks:
+    - tosit.tdp.resolve: # noqa unnamed-task
+        node_name: hbase_regionserver
+    - name: HBase RegionServer status
+      import_role:
+        name: tosit.tdp.hbase.regionserver
+        tasks_from: status
+    - meta: clear_facts # noqa unnamed-task

--- a/playbooks/hbase_rest_status.yml
+++ b/playbooks/hbase_rest_status.yml
@@ -1,0 +1,14 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: HBase REST status
+  hosts: hbase_rest
+  tasks:
+    - tosit.tdp.resolve: # noqa unnamed-task
+        node_name: hbase_rest
+    - name: HBase REST status
+      import_role:
+        name: tosit.tdp.hbase.rest
+        tasks_from: status
+    - meta: clear_facts # noqa unnamed-task

--- a/playbooks/hdfs_datanode_status.yml
+++ b/playbooks/hdfs_datanode_status.yml
@@ -1,0 +1,14 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Hadoop HDFS datanode status
+  hosts: hdfs_dn
+  tasks:
+    - tosit.tdp.resolve: # noqa unnamed-task
+        node_name: hdfs_datanode
+    - name: HDFS datanode status
+      import_role:
+        name: tosit.tdp.hdfs.datanode
+        tasks_from: status
+    - meta: clear_facts # noqa unnamed-task

--- a/playbooks/hdfs_httpfs_status.yml
+++ b/playbooks/hdfs_httpfs_status.yml
@@ -1,0 +1,14 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Hadoop HDFS HttpFs status
+  hosts: hdfs_httpfs
+  tasks:
+    - tosit.tdp.resolve: # noqa unnamed-task
+        node_name: hdfs_httpfs
+    - name: HDFS HttpFs status
+      import_role:
+        name: tosit.tdp.hdfs.httpfs
+        tasks_from: status
+    - meta: clear_facts # noqa unnamed-task

--- a/playbooks/hdfs_journalnode_status.yml
+++ b/playbooks/hdfs_journalnode_status.yml
@@ -1,0 +1,14 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Hadoop HDFS journalnode status
+  hosts: hdfs_jn
+  tasks:
+    - tosit.tdp.resolve: # noqa unnamed-task
+        node_name: hdfs_journalnode
+    - name: HDFS journalnode status
+      import_role:
+        name: tosit.tdp.hdfs.journalnode
+        tasks_from: status
+    - meta: clear_facts # noqa unnamed-task

--- a/playbooks/hdfs_namenode_status.yml
+++ b/playbooks/hdfs_namenode_status.yml
@@ -1,0 +1,14 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Hadoop HDFS namenode status
+  hosts: hdfs_nn
+  tasks:
+    - tosit.tdp.resolve: # noqa unnamed-task
+        node_name: hdfs_namenode
+    - name: HDFS namenode status
+      import_role:
+        name: tosit.tdp.hdfs.namenode
+        tasks_from: status
+    - meta: clear_facts # noqa unnamed-task

--- a/playbooks/hive_hiveserver2_status.yml
+++ b/playbooks/hive_hiveserver2_status.yml
@@ -1,0 +1,14 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Hive Server 2 status
+  hosts: hive_s2
+  tasks:
+    - tosit.tdp.resolve: # noqa unnamed-task
+        node_name: hive_hiveserver2
+    - name: Hive HiveServer2
+      import_role:
+        name: tosit.tdp.hive.hiveserver2
+        tasks_from: status
+    - meta: clear_facts # noqa unnamed-task

--- a/playbooks/hive_metastore_status.yml
+++ b/playbooks/hive_metastore_status.yml
@@ -1,0 +1,14 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Hive Metastore status
+  hosts: hive_ms
+  tasks:
+    - tosit.tdp.resolve: # noqa unnamed-task
+        node_name: hive_metastore
+    - name: Hive Metastore status
+      import_role:
+        name: tosit.tdp.hive.metastore
+        tasks_from: status
+    - meta: clear_facts # noqa unnamed-task

--- a/playbooks/knox_gateway_status.yml
+++ b/playbooks/knox_gateway_status.yml
@@ -1,0 +1,14 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Knox Gateway status
+  hosts: knox
+  tasks:
+    - tosit.tdp.resolve: # noqa unnamed-task
+        node_name: knox_gateway
+    - name: Knox Gateway status
+      import_role:
+        name: tosit.tdp.knox.gateway
+        tasks_from: status
+    - meta: clear_facts # noqa unnamed-task

--- a/playbooks/ranger_admin_status.yml
+++ b/playbooks/ranger_admin_status.yml
@@ -1,0 +1,14 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Ranger Admin status
+  hosts: ranger_admin
+  tasks:
+    - tosit.tdp.resolve: # noqa unnamed-task
+        node_name: ranger_admin
+    - name: Ranger Admin status
+      import_role:
+        name: tosit.tdp.ranger.admin
+        tasks_from: status
+    - meta: clear_facts # noqa unnamed-task

--- a/playbooks/ranger_kms_status.yml
+++ b/playbooks/ranger_kms_status.yml
@@ -1,0 +1,14 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Ranger KMS status
+  hosts: ranger_kms
+  tasks:
+    - tosit.tdp.resolve: # noqa unnamed-task
+        node_name: ranger_kms
+    - name: Ranger KMS status
+      import_role:
+        name: tosit.tdp.ranger.kms
+        tasks_from: status
+    - meta: clear_facts # noqa unnamed-task

--- a/playbooks/ranger_solr_status.yml
+++ b/playbooks/ranger_solr_status.yml
@@ -1,0 +1,14 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Ranger Solr status
+  hosts: ranger_solr
+  tasks:
+    - tosit.tdp.resolve: # noqa unnamed-task
+        node_name: ranger_solr
+    - name: Ranger Solr status
+      import_role:
+        name: tosit.tdp.ranger.solr
+        tasks_from: status
+    - meta: clear_facts # noqa unnamed-task

--- a/playbooks/ranger_usersync_status.yml
+++ b/playbooks/ranger_usersync_status.yml
@@ -1,0 +1,14 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Ranger Usersync status
+  hosts: ranger_usersync
+  tasks:
+    - tosit.tdp.resolve: # noqa unnamed-task
+        node_name: ranger_usersync
+    - name: Ranger UserSync status
+      import_role:
+        name: tosit.tdp.ranger.usersync
+        tasks_from: status
+    - meta: clear_facts # noqa unnamed-task

--- a/playbooks/spark3_historyserver_status.yml
+++ b/playbooks/spark3_historyserver_status.yml
@@ -1,0 +1,14 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Spark History Server status
+  hosts: spark3_hs
+  tasks:
+    - tosit.tdp.resolve: # noqa unnamed-task
+        node_name: spark3_historyserver
+    - name: Spark3 History Server status
+      import_role:
+        name: tosit.tdp.spark.historyserver
+        tasks_from: status
+    - meta: clear_facts # noqa unnamed-task

--- a/playbooks/spark_historyserver_status.yml
+++ b/playbooks/spark_historyserver_status.yml
@@ -1,0 +1,14 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Spark History Server status
+  hosts: spark_hs
+  tasks:
+    - tosit.tdp.resolve: # noqa unnamed-task
+        node_name: spark_historyserver
+    - name: Spark History Server status
+      import_role:
+        name: tosit.tdp.spark.historyserver
+        tasks_from: status
+    - meta: clear_facts # noqa unnamed-task

--- a/playbooks/yarn_apptimelineserver_status.yml
+++ b/playbooks/yarn_apptimelineserver_status.yml
@@ -1,0 +1,14 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Hadoop Yarn App Timeline Server status
+  hosts: yarn_ats
+  tasks:
+    - tosit.tdp.resolve: # noqa unnamed-task
+        node_name: yarn_apptimelineserver
+    - name: YARN ATS status
+      import_role:
+        name: tosit.tdp.yarn.apptimelineserver
+        tasks_from: status
+    - meta: clear_facts # noqa unnamed-task

--- a/playbooks/yarn_mapred_jobhistoryserver_status.yml
+++ b/playbooks/yarn_mapred_jobhistoryserver_status.yml
@@ -1,0 +1,14 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Hadoop Yarn Mapred Job History Server status
+  hosts: mapred_jhs
+  tasks:
+    - tosit.tdp.resolve: # noqa unnamed-task
+        node_name: yarn_jobhistoryserver
+    - name: YARN Mapred JHS status
+      import_role:
+        name: tosit.tdp.yarn.jobhistoryserver
+        tasks_from: status
+    - meta: clear_facts # noqa unnamed-task

--- a/playbooks/yarn_nodemanager_status.yml
+++ b/playbooks/yarn_nodemanager_status.yml
@@ -1,0 +1,14 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Hadoop Yarn nodemanager status
+  hosts: yarn_nm
+  tasks:
+    - tosit.tdp.resolve: # noqa unnamed-task
+        node_name: yarn_nodemanager
+    - name: YARN NM status
+      import_role:
+        name: tosit.tdp.yarn.nodemanager
+        tasks_from: status
+    - meta: clear_facts # noqa unnamed-task

--- a/playbooks/yarn_resourcemanager_status.yml
+++ b/playbooks/yarn_resourcemanager_status.yml
@@ -1,0 +1,14 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Hadoop Yarn resourcemanager status
+  hosts: yarn_rm
+  tasks:
+    - tosit.tdp.resolve: # noqa unnamed-task
+        node_name: yarn_resourcemanager
+    - name: YARN RM status
+      import_role:
+        name: tosit.tdp.yarn.resourcemanager
+        tasks_from: status
+    - meta: clear_facts # noqa unnamed-task

--- a/playbooks/zookeeper_server_status.yml
+++ b/playbooks/zookeeper_server_status.yml
@@ -1,0 +1,14 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Zookeeper Server Status
+  hosts: zk
+  tasks:
+    - tosit.tdp.resolve: # noqa unnamed-task
+        node_name: zookeeper_server
+    - name: zookeeper server status
+      import_role:
+        name: tosit.tdp.zookeeper.server
+        tasks_from: status
+    - meta: clear_facts # noqa unnamed-task

--- a/roles/exporter/node/tasks/status.yml
+++ b/roles/exporter/node/tasks/status.yml
@@ -1,0 +1,12 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Populate service facts
+  service_facts:
+
+- name: Assert node-exporter is running 
+  assert:
+    that:
+      - ansible_facts.services['node-exporter.service'].state == "running"
+    quiet: true

--- a/roles/hbase/master/tasks/status.yml
+++ b/roles/hbase/master/tasks/status.yml
@@ -1,0 +1,12 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Populate service facts
+  service_facts:
+
+- name: Assert hbase-master is running 
+  assert:
+    that:
+      - ansible_facts.services['hbase-master.service'].state == "running"
+    quiet: true

--- a/roles/hbase/phoenix/queryserver/daemon/tasks/status.yml
+++ b/roles/hbase/phoenix/queryserver/daemon/tasks/status.yml
@@ -1,0 +1,12 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Populate service facts
+  service_facts:
+
+- name: Assert phoenix-queryserver is running 
+  assert:
+    that:
+      - ansible_facts.services['phoenix-queryserver.service'].state == "running"
+    quiet: true

--- a/roles/hbase/regionserver/tasks/status.yml
+++ b/roles/hbase/regionserver/tasks/status.yml
@@ -1,0 +1,12 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Populate service facts
+  service_facts:
+
+- name: Assert hbase-regionserver is running 
+  assert:
+    that:
+      - ansible_facts.services['hbase-regionserver.service'].state == "running"
+    quiet: true

--- a/roles/hbase/rest/tasks/status.yml
+++ b/roles/hbase/rest/tasks/status.yml
@@ -1,0 +1,12 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Populate service facts
+  service_facts:
+
+- name: Assert hbase-rest is running 
+  assert:
+    that:
+      - ansible_facts.services['hbase-rest.service'].state == "running"
+    quiet: true

--- a/roles/hdfs/datanode/tasks/status.yml
+++ b/roles/hdfs/datanode/tasks/status.yml
@@ -1,0 +1,12 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Populate service facts
+  service_facts:
+
+- name: Assert hadoop-hdfs-datanode is running 
+  assert:
+    that:
+      - ansible_facts.services['hadoop-hdfs-datanode.service'].state == "running"
+    quiet: true

--- a/roles/hdfs/httpfs/tasks/status.yml
+++ b/roles/hdfs/httpfs/tasks/status.yml
@@ -1,0 +1,12 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Populate service facts
+  service_facts:
+
+- name: Assert hadoop-hdfs-httpfs is running 
+  assert:
+    that:
+      - ansible_facts.services['hadoop-hdfs-httpfs.service'].state == "running"
+    quiet: true

--- a/roles/hdfs/journalnode/tasks/status.yml
+++ b/roles/hdfs/journalnode/tasks/status.yml
@@ -1,0 +1,12 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Populate service facts
+  service_facts:
+
+- name: Assert hadoop-hdfs-journalnode is running 
+  assert:
+    that:
+      - ansible_facts.services['hadoop-hdfs-journalnode.service'].state == "running"
+    quiet: true

--- a/roles/hdfs/namenode/tasks/status.yml
+++ b/roles/hdfs/namenode/tasks/status.yml
@@ -1,0 +1,18 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Populate service facts
+  service_facts:
+
+- name: Assert hadoop-hdfs-namenode is running 
+  assert:
+    that:
+      - ansible_facts.services['hadoop-hdfs-namenode.service'].state == "running"
+    quiet: true
+
+- name: Assert hadoop-hdfs-zkfc is running 
+  assert:
+    that:
+      - ansible_facts.services['hadoop-hdfs-zkfc.service'].state == "running"
+    quiet: true

--- a/roles/hive/hiveserver2/tasks/status.yml
+++ b/roles/hive/hiveserver2/tasks/status.yml
@@ -1,0 +1,12 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Populate service facts
+  service_facts:
+
+- name: Assert hive-server2 is running 
+  assert:
+    that:
+      - ansible_facts.services['hive-server2.service'].state == "running"
+    quiet: true

--- a/roles/hive/metastore/tasks/status.yml
+++ b/roles/hive/metastore/tasks/status.yml
@@ -1,0 +1,12 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Populate service facts
+  service_facts:
+
+- name: Assert hive-metastore is running 
+  assert:
+    that:
+      - ansible_facts.services['hive-metastore.service'].state == "running"
+    quiet: true

--- a/roles/knox/gateway/tasks/status.yml
+++ b/roles/knox/gateway/tasks/status.yml
@@ -1,0 +1,12 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Populate service facts
+  service_facts:
+
+- name: Assert knox-gateway is running 
+  assert:
+    that:
+      - ansible_facts.services['knox-gateway.service'].state == "running"
+    quiet: true

--- a/roles/ranger/admin/tasks/status.yml
+++ b/roles/ranger/admin/tasks/status.yml
@@ -1,0 +1,12 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Populate service facts
+  service_facts:
+
+- name: Assert ranger-admin is running 
+  assert:
+    that:
+      - ansible_facts.services['ranger-admin.service'].state == "running"
+    quiet: true

--- a/roles/ranger/kms/tasks/status.yml
+++ b/roles/ranger/kms/tasks/status.yml
@@ -1,0 +1,12 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Populate service facts
+  service_facts:
+
+- name: Assert ranger-kms is running 
+  assert:
+    that:
+      - ansible_facts.services['ranger-kms.service'].state == "running"
+    quiet: true

--- a/roles/ranger/solr/tasks/status.yml
+++ b/roles/ranger/solr/tasks/status.yml
@@ -1,0 +1,12 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Populate service facts
+  service_facts:
+
+- name: Assert solr is running 
+  assert:
+    that:
+      - ansible_facts.services['solr.service'].state == "running"
+    quiet: true

--- a/roles/ranger/usersync/tasks/status.yml
+++ b/roles/ranger/usersync/tasks/status.yml
@@ -1,0 +1,12 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Populate service facts
+  service_facts:
+
+- name: Assert ranger-usersync is running 
+  assert:
+    that:
+      - ansible_facts.services['ranger-usersync.service'].state == "running"
+    quiet: true

--- a/roles/spark/historyserver/tasks/status.yml
+++ b/roles/spark/historyserver/tasks/status.yml
@@ -1,0 +1,12 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Populate service facts
+  service_facts:
+
+- name: "Assert {{ spark_version | capitalize }} is running"
+  assert:
+    that:
+      - ansible_facts.services['{{ spark_version }}-history-server.service'].state == "running"
+    quiet: true

--- a/roles/yarn/apptimelineserver/tasks/status.yml
+++ b/roles/yarn/apptimelineserver/tasks/status.yml
@@ -1,0 +1,12 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Populate service facts
+  service_facts:
+
+- name: Assert hadoop-yarn-timelineserver is running 
+  assert:
+    that:
+      - ansible_facts.services['hadoop-yarn-timelineserver.service'].state == "running"
+    quiet: true

--- a/roles/yarn/jobhistoryserver/tasks/status.yml
+++ b/roles/yarn/jobhistoryserver/tasks/status.yml
@@ -1,0 +1,12 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Populate service facts
+  service_facts:
+
+- name: Assert hadoop-mapred-jobhistoryserver is running 
+  assert:
+    that:
+      - ansible_facts.services['hadoop-mapred-jobhistoryserver.service'].state == "running"
+    quiet: true

--- a/roles/yarn/nodemanager/tasks/status.yml
+++ b/roles/yarn/nodemanager/tasks/status.yml
@@ -1,0 +1,12 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Populate service facts
+  service_facts:
+
+- name: Assert hadoop-yarn-nodemanager is running 
+  assert:
+    that:
+      - ansible_facts.services['hadoop-yarn-nodemanager.service'].state == "running"
+    quiet: true

--- a/roles/yarn/resourcemanager/tasks/status.yml
+++ b/roles/yarn/resourcemanager/tasks/status.yml
@@ -1,0 +1,12 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Populate service facts
+  service_facts:
+
+- name: Assert hadoop-yarn-resourcemanager is running 
+  assert:
+    that:
+      - ansible_facts.services['hadoop-yarn-resourcemanager.service'].state == "running"
+    quiet: true

--- a/roles/zookeeper/server/tasks/status.yml
+++ b/roles/zookeeper/server/tasks/status.yml
@@ -1,0 +1,12 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Populate service facts
+  service_facts:
+
+- name: "Assert {{ zookeeper_server_service_name }} is running" 
+  assert:
+    that:
+      - ansible_facts.services['{{ zookeeper_server_service_name }}.service'].state == "running"
+    quiet: true


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #631 
Fixes #186 

#### Additional comments

I did not add the status tasks in the DAG yet because I'm not sure where to put them. A `*_*_status` should depend on `*_*_start` but do we want `*_*_init` tasks to depend on `*_*_status` tasks? 

I don't have a strong opinion but I guess it would improve overall trust in a deployment since some services can fail silently a few seconds after the `*_*_start` task. But those might be missed anyway in the case where a service is in a restart loop.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
