### PR TITLE
fix: set hive default heapsize

### DIFF
--- a/roles/hive/common/templates/hive-env.sh.j2
+++ b/roles/hive/common/templates/hive-env.sh.j2
@@ -47,12 +47,14 @@ export HADOOP_HOME={{ hadoop_home }}
 export JAVA_HOME={{ java_home }}
 export AUX_CLASSPATH="/opt/tdp/tez/*:/opt/tdp/tez/lib/*"
 
+export HADOOP_HEAPSIZE="{{ hive_default_heapsize }}"
+
 # The heap size of the jvm, and jvm args stared by hive shell script can be controlled via:
 if [ "$SERVICE" = "metastore" ]; then
 
   export JMX_OPTS="{{ jmx_common_opts }} -Dcom.sun.management.jmxremote.password.file={{ hive_ms_conf_dir }}/jmxremote.password  {{ jmx_exporter_hms_opts }} "
   # Setting for HiveMetastore
-  export HADOOP_HEAPSIZE={{ hive_metastore_heapsize }} 
+  export HADOOP_HEAPSIZE="{{ hive_metastore_heapsize }}" 
   export HADOOP_OPTS="$HADOOP_OPTS $JMX_OPTS -Xloggc:{{ hive_log_dir }}/metastore-gc-%t.log -XX:+UseG1GC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCCause -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=10M -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath={{ hive_log_dir }}/hms_heapdump.hprof"
 
 fi
@@ -61,13 +63,12 @@ if [ "$SERVICE" = "hiveserver2" ]; then
 
   export JMX_OPTS="{{ jmx_common_opts }} -Dcom.sun.management.jmxremote.password.file={{ hive_s2_conf_dir }}/jmxremote.password  {{ jmx_exporter_hs2_opts }} "
   # Setting for HiveServer2 and Client
-  export HADOOP_HEAPSIZE={{ hive_hs2_heapsize }}
+  export HADOOP_HEAPSIZE="{{ hive_hs2_heapsize }}"
   export HADOOP_OPTS="$HADOOP_OPTS $JMX_OPTS -Xloggc:{{ hive_log_dir }}/hiveserver2-gc-%t.log -XX:+UseG1GC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCCause -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=10M -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath={{ hive_log_dir }}/hs2_heapdump.hprof"
 
 fi
 
-export HADOOP_CLIENT_OPTS="$HADOOP_CLIENT_OPTS  -Xmx${HADOOP_HEAPSIZE}"
-export HADOOP_CLIENT_OPTS="$HADOOP_CLIENT_OPTS"
+export HADOOP_CLIENT_OPTS="$HADOOP_CLIENT_OPTS -Xmx${HADOOP_HEAPSIZE}"
 
 export HIVE_HOME={{ hive_install_dir }}
 

--- a/tdp_vars_defaults/hive/hive.yml
+++ b/tdp_vars_defaults/hive/hive.yml
@@ -180,6 +180,7 @@ hiveserver2_restart: "no"
 hivemetastore_restart: "no"
 
 # Hive_resources allocation
+hive_default_heapsize: 256m
 hive_hs2_heapsize: 1024m
 hive_metastore_heapsize: 1024m
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #638

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

Templating hive-env to set a default heapsize, configurable in hive's tdp_vars

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
