### PR TITLE
feat: add fluentbit log tail configuration for each service

### DIFF
--- a/roles/hbase/master/tasks/config.yml
+++ b/roles/hbase/master/tasks/config.yml
@@ -62,3 +62,8 @@
     owner: root
     group: root
     mode: "644"
+
+- name: Run fluentbit configuration
+  import_role:
+    name: tosit.tdp.utils.fluentbit
+    tasks_from: config

--- a/roles/hbase/phoenix/queryserver/daemon/tasks/config.yml
+++ b/roles/hbase/phoenix/queryserver/daemon/tasks/config.yml
@@ -51,3 +51,8 @@
     owner: root
     group: root
     mode: "644"
+
+- name: Run fluentbit configuration
+  import_role:
+    name: tosit.tdp.utils.fluentbit
+    tasks_from: config

--- a/roles/hbase/regionserver/tasks/config.yml
+++ b/roles/hbase/regionserver/tasks/config.yml
@@ -62,3 +62,8 @@
     owner: root
     group: root
     mode: "644"
+
+- name: Run fluentbit configuration
+  import_role:
+    name: tosit.tdp.utils.fluentbit
+    tasks_from: config

--- a/roles/hbase/rest/tasks/config.yml
+++ b/roles/hbase/rest/tasks/config.yml
@@ -62,3 +62,8 @@
     owner: root
     group: root
     mode: "644"
+
+- name: Run fluentbit configuration
+  import_role:
+    name: tosit.tdp.utils.fluentbit
+    tasks_from: config

--- a/roles/hdfs/datanode/tasks/config.yml
+++ b/roles/hdfs/datanode/tasks/config.yml
@@ -58,3 +58,8 @@
     owner: root
     group: root
     mode: "644"
+
+- name: Run fluentbit configuration
+  import_role:
+    name: tosit.tdp.utils.fluentbit
+    tasks_from: config

--- a/roles/hdfs/httpfs/tasks/config.yml
+++ b/roles/hdfs/httpfs/tasks/config.yml
@@ -74,3 +74,8 @@
     owner: root
     group: root
     mode: "644"
+
+- name: Run fluentbit configuration
+  import_role:
+    name: tosit.tdp.utils.fluentbit
+    tasks_from: config

--- a/roles/hdfs/journalnode/tasks/config.yml
+++ b/roles/hdfs/journalnode/tasks/config.yml
@@ -58,3 +58,8 @@
     owner: root
     group: root
     mode: "644"
+
+- name: Run fluentbit configuration
+  import_role:
+    name: tosit.tdp.utils.fluentbit
+    tasks_from: config

--- a/roles/hdfs/namenode/tasks/config.yml
+++ b/roles/hdfs/namenode/tasks/config.yml
@@ -74,3 +74,8 @@
     owner: root
     group: root
     mode: "644"
+
+- name: Run fluentbit configuration
+  import_role:
+    name: tosit.tdp.utils.fluentbit
+    tasks_from: config

--- a/roles/hive/hiveserver2/tasks/config.yml
+++ b/roles/hive/hiveserver2/tasks/config.yml
@@ -62,3 +62,8 @@
     owner: root
     group: root
     mode: "644"
+
+- name: Run fluentbit configuration
+  import_role:
+    name: tosit.tdp.utils.fluentbit
+    tasks_from: config

--- a/roles/hive/metastore/tasks/config.yml
+++ b/roles/hive/metastore/tasks/config.yml
@@ -70,3 +70,8 @@
     owner: root
     group: root
     mode: "644"
+
+- name: Run fluentbit configuration
+  import_role:
+    name: tosit.tdp.utils.fluentbit
+    tasks_from: config

--- a/roles/knox/gateway/tasks/config.yml
+++ b/roles/knox/gateway/tasks/config.yml
@@ -212,3 +212,8 @@
     owner: root
     group: root
     mode: "644"
+
+- name: Run fluentbit configuration
+  import_role:
+    name: tosit.tdp.utils.fluentbit
+    tasks_from: config

--- a/roles/ranger/admin/tasks/config.yml
+++ b/roles/ranger/admin/tasks/config.yml
@@ -66,3 +66,8 @@
   vars:
     configuration_file: "{{ ranger_install_dir }}/conf/ranger-admin-site.xml"
     merge_var: "{{ ranger_admin_site }}"
+
+- name: Run fluentbit configuration
+  import_role:
+    name: tosit.tdp.utils.fluentbit
+    tasks_from: config

--- a/roles/ranger/kms/tasks/config.yml
+++ b/roles/ranger/kms/tasks/config.yml
@@ -73,3 +73,8 @@
   vars:
     configuration_file: "{{ ranger_kms_conf_dir }}/conf/ranger-kms-site.xml"
     merge_var: "{{ ranger_kms_site }}"
+
+- name: Run fluentbit configuration
+  import_role:
+    name: tosit.tdp.utils.fluentbit
+    tasks_from: config

--- a/roles/ranger/usersync/tasks/config.yml
+++ b/roles/ranger/usersync/tasks/config.yml
@@ -33,3 +33,8 @@
     owner: "{{ ranger_user }}"
     group: "{{ hadoop_group }}"
     mode: "750"
+
+- name: Run fluentbit configuration
+  import_role:
+    name: tosit.tdp.utils.fluentbit
+    tasks_from: config

--- a/roles/spark/historyserver/tasks/config.yml
+++ b/roles/spark/historyserver/tasks/config.yml
@@ -40,3 +40,8 @@
     owner: root
     group: root
     mode: "644"
+
+- name: Run fluentbit configuration
+  import_role:
+    name: tosit.tdp.utils.fluentbit
+    tasks_from: config

--- a/roles/utils/fluentbit/tasks/config.yml
+++ b/roles/utils/fluentbit/tasks/config.yml
@@ -1,0 +1,9 @@
+# Copyright 2023 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Render fluent-bit.conf
+  template:
+    src: fluent-bit.conf.j2
+    dest: "{{ fluent_bit_configuration_file }}"
+    mode: 0644

--- a/roles/utils/fluentbit/tasks/config.yml
+++ b/roles/utils/fluentbit/tasks/config.yml
@@ -1,4 +1,4 @@
-# Copyright 2023 TOSIT.IO
+# Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
 ---

--- a/roles/utils/fluentbit/tasks/fluent-bit.conf.j2
+++ b/roles/utils/fluentbit/tasks/fluent-bit.conf.j2
@@ -1,0 +1,11 @@
+{% if fluent_bit_configuration | length > 0 %}
+{% for section in fluent_bit_configuration%}
+[{{ section }}]
+{% if fluent_bit_configuration[section].items is defined %}
+{% for key, value in fluent_bit_configuration[section].items() %}
+    {{ key }} {{ value }}
+{% endfor %}
+
+{% endif %}
+{% endfor%}
+{% endif %}

--- a/roles/yarn/apptimelineserver/tasks/config.yml
+++ b/roles/yarn/apptimelineserver/tasks/config.yml
@@ -67,3 +67,8 @@
     owner: root
     group: root
     mode: "644"
+
+- name: Run fluentbit configuration
+  import_role:
+    name: tosit.tdp.utils.fluentbit
+    tasks_from: config

--- a/roles/yarn/jobhistoryserver/tasks/config.yml
+++ b/roles/yarn/jobhistoryserver/tasks/config.yml
@@ -75,3 +75,8 @@
     owner: root
     group: root
     mode: "644"
+
+- name: Run fluentbit configuration
+  import_role:
+    name: tosit.tdp.utils.fluentbit
+    tasks_from: config

--- a/roles/yarn/nodemanager/tasks/config.yml
+++ b/roles/yarn/nodemanager/tasks/config.yml
@@ -78,3 +78,8 @@
     owner: root
     group: root
     mode: "644"
+
+- name: Run fluentbit configuration
+  import_role:
+    name: tosit.tdp.utils.fluentbit
+    tasks_from: config

--- a/roles/yarn/resourcemanager/tasks/config.yml
+++ b/roles/yarn/resourcemanager/tasks/config.yml
@@ -91,3 +91,8 @@
     owner: root
     group: root
     mode: "644"
+
+- name: Run fluentbit configuration
+  import_role:
+    name: tosit.tdp.utils.fluentbit
+    tasks_from: config

--- a/roles/zookeeper/server/tasks/config.yml
+++ b/roles/zookeeper/server/tasks/config.yml
@@ -37,7 +37,6 @@
     owner: root
     mode: "644"
 
-
 - name: Template zookeeper-env.sh
   template:
     src: zookeeper-env.sh.j2
@@ -46,7 +45,6 @@
     owner: root
     mode: "644"
 
-
 - name: Render jmxremote.password
   template:
     src: jmxremote.password.j2
@@ -54,3 +52,8 @@
     group: root
     owner: root
     mode: "644"
+
+- name: Run fluentbit configuration
+  import_role:
+    name: tosit.tdp.utils.fluentbit
+    tasks_from: config

--- a/tdp_vars_defaults/hbase/hbase_master.yml
+++ b/tdp_vars_defaults/hbase/hbase_master.yml
@@ -1,0 +1,10 @@
+# Copyright 2023 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+# Fluentbit configuration
+fluent_bit_configuration_file: "{{ hbase_master_conf_dir }}/hbase-master-fluent-bit.conf"
+fluent_bit_configuration:
+  INPUT:
+    Name: tail
+    Path: "{{ hbase_log_dir }}/hbase-{{ hbase_user }}-master-{{ ansible_fqdn }}.log"

--- a/tdp_vars_defaults/hbase/hbase_master.yml
+++ b/tdp_vars_defaults/hbase/hbase_master.yml
@@ -1,4 +1,4 @@
-# Copyright 2023 TOSIT.IO
+# Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
 ---

--- a/tdp_vars_defaults/hbase/hbase_phoenix_queryserver_daemon.yml
+++ b/tdp_vars_defaults/hbase/hbase_phoenix_queryserver_daemon.yml
@@ -1,0 +1,10 @@
+# Copyright 2023 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+# Fluentbit configuration
+fluent_bit_configuration_file: "{{ hbase_phoenix_queryserver_daemon_conf_dir }}/phoenix-queryserver-fluent-bit.conf"
+fluent_bit_configuration:
+  INPUT:
+    Name: tail
+    Path: "{{ phoenix_queryserver_log_dir }}/phoenix-{{ phoenix_queryserver_user }}-queryserver.log"

--- a/tdp_vars_defaults/hbase/hbase_phoenix_queryserver_daemon.yml
+++ b/tdp_vars_defaults/hbase/hbase_phoenix_queryserver_daemon.yml
@@ -1,4 +1,4 @@
-# Copyright 2023 TOSIT.IO
+# Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
 ---

--- a/tdp_vars_defaults/hbase/hbase_regionserver.yml
+++ b/tdp_vars_defaults/hbase/hbase_regionserver.yml
@@ -1,0 +1,10 @@
+# Copyright 2023 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+# Fluentbit configuration
+fluent_bit_configuration_file: "{{ hbase_rs_conf_dir }}/hbase-rs-fluent-bit.conf"
+fluent_bit_configuration:
+  INPUT:
+    Name: tail
+    Path: "{{ hbase_log_dir }}/hbase-{{ hbase_user }}-regionserver-{{ ansible_fqdn }}.log"

--- a/tdp_vars_defaults/hbase/hbase_regionserver.yml
+++ b/tdp_vars_defaults/hbase/hbase_regionserver.yml
@@ -1,4 +1,4 @@
-# Copyright 2023 TOSIT.IO
+# Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
 ---

--- a/tdp_vars_defaults/hbase/hbase_rest.yml
+++ b/tdp_vars_defaults/hbase/hbase_rest.yml
@@ -1,0 +1,10 @@
+# Copyright 2023 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+# Fluentbit configuration
+fluent_bit_configuration_file: "{{ hbase_rest_conf_dir }}/hbase-rest-fluent-bit.conf"
+fluent_bit_configuration:
+  INPUT:
+    Name: tail
+    Path: "{{ hbase_log_dir }}/hbase-{{ hbase_user }}-rest-{{ ansible_fqdn }}.log"

--- a/tdp_vars_defaults/hbase/hbase_rest.yml
+++ b/tdp_vars_defaults/hbase/hbase_rest.yml
@@ -1,4 +1,4 @@
-# Copyright 2023 TOSIT.IO
+# Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
 ---

--- a/tdp_vars_defaults/hdfs/hdfs_datanode.yml
+++ b/tdp_vars_defaults/hdfs/hdfs_datanode.yml
@@ -1,4 +1,4 @@
-# Copyright 2023 TOSIT.IO
+# Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
 ---

--- a/tdp_vars_defaults/hdfs/hdfs_datanode.yml
+++ b/tdp_vars_defaults/hdfs/hdfs_datanode.yml
@@ -1,0 +1,10 @@
+# Copyright 2023 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+# Fluentbit configuration
+fluent_bit_configuration_file: "{{ hadoop_dn_conf_dir }}/hdfs-dn-fluent-bit.conf"
+fluent_bit_configuration:
+  INPUT:
+    Name: tail
+    Path: "{{ hadoop_hdfs_log_dir }}/hadoop-{{ hdfs_user }}-datanode-{{ ansible_fqdn }}.log"

--- a/tdp_vars_defaults/hdfs/hdfs_httpfs.yml
+++ b/tdp_vars_defaults/hdfs/hdfs_httpfs.yml
@@ -24,3 +24,10 @@ httpfs_site:
   httpfs.proxyuser.hue.groups: '*'
   httpfs.proxyuser.hdfs.hosts: '*'
   httpfs.proxyuser.hdfs.groups: '*'
+
+# Fluentbit configuration
+fluent_bit_configuration_file: "{{ hadoop_httpfs_conf_dir }}/hdfs-httpfs-fluent-bit.conf"
+fluent_bit_configuration:
+  INPUT:
+    Name: tail
+    Path: "{{ hadoop_hdfs_log_dir }}/hadoop-{{ hdfs_user }}-httpfs-{{ ansible_fqdn }}.log"

--- a/tdp_vars_defaults/hdfs/hdfs_journalnode.yml
+++ b/tdp_vars_defaults/hdfs/hdfs_journalnode.yml
@@ -1,4 +1,4 @@
-# Copyright 2023 TOSIT.IO
+# Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
 ---

--- a/tdp_vars_defaults/hdfs/hdfs_journalnode.yml
+++ b/tdp_vars_defaults/hdfs/hdfs_journalnode.yml
@@ -1,0 +1,10 @@
+# Copyright 2023 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+# Fluentbit configuration
+fluent_bit_configuration_file: "{{ hadoop_jn_conf_dir }}/hdfs-jn-fluent-bit.conf"
+fluent_bit_configuration:
+  INPUT:
+    Name: tail
+    Path: "{{ hadoop_hdfs_log_dir }}/hadoop-{{ hdfs_user }}-journalnode-{{ ansible_fqdn }}.log"

--- a/tdp_vars_defaults/hdfs/hdfs_namenode.yml
+++ b/tdp_vars_defaults/hdfs/hdfs_namenode.yml
@@ -4,3 +4,10 @@
 ---
 hdfs_site:
   dfs.hosts.exclude: "{{ hadoop_nn_conf_dir }}/dfs.exclude"
+
+# Fluentbit configuration
+fluent_bit_configuration_file: "{{ hadoop_nn_conf_dir }}/hdfs-nn-fluent-bit.conf"
+fluent_bit_configuration:
+  INPUT:
+    Name: tail
+    Path: "{{ hadoop_hdfs_log_dir }}/hadoop-{{ hdfs_user }}-namenode-{{ ansible_fqdn }}.log, {{ hadoop_hdfs_log_dir }}/hadoop-{{ hdfs_user }}-zkfc-{{ ansible_fqdn }}.log"

--- a/tdp_vars_defaults/hive/hive_hiveserver2.yml
+++ b/tdp_vars_defaults/hive/hive_hiveserver2.yml
@@ -1,0 +1,10 @@
+# Copyright 2023 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+# Fluentbit configuration
+fluent_bit_configuration_file: "{{ hive_s2_conf_dir }}/hive-s2-fluent-bit.conf"
+fluent_bit_configuration:
+  INPUT:
+    Name: tail
+    Path: "{{ hive_log_dir }}/{{ hive_s2_log_file }}"

--- a/tdp_vars_defaults/hive/hive_hiveserver2.yml
+++ b/tdp_vars_defaults/hive/hive_hiveserver2.yml
@@ -1,4 +1,4 @@
-# Copyright 2023 TOSIT.IO
+# Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
 ---

--- a/tdp_vars_defaults/hive/hive_metastore.yml
+++ b/tdp_vars_defaults/hive/hive_metastore.yml
@@ -8,3 +8,10 @@ hive_ms_credentials_store_uri: localjceks://file{{ hive_ms_credentials_store_pat
 
 hive_site:
   hadoop.security.credential.provider.path: "{{ hive_ms_credentials_store_uri }}"
+
+# Fluentbit configuration
+fluent_bit_configuration_file: "{{ hive_ms_conf_dir }}/hive-ms-fluent-bit.conf"
+fluent_bit_configuration:
+  INPUT:
+    Name: tail
+    Path: "{{ hive_log_dir }}/{{ hive_ms_log_file }}"

--- a/tdp_vars_defaults/knox/knox_gateway.yml
+++ b/tdp_vars_defaults/knox/knox_gateway.yml
@@ -1,0 +1,10 @@
+# Copyright 2023 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+# Fluentbit configuration
+fluent_bit_configuration_file: "{{ knox_conf_dir }}/knox-gateway-fluent-bit.conf"
+fluent_bit_configuration:
+  INPUT:
+    Name: tail
+    Path: "{{ knox_log_dir }}/gateway-audit.log, {{ knox_log_dir }}/gateway.log"

--- a/tdp_vars_defaults/knox/knox_gateway.yml
+++ b/tdp_vars_defaults/knox/knox_gateway.yml
@@ -1,4 +1,4 @@
-# Copyright 2023 TOSIT.IO
+# Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
 ---

--- a/tdp_vars_defaults/ranger/ranger_admin.yml
+++ b/tdp_vars_defaults/ranger/ranger_admin.yml
@@ -1,0 +1,10 @@
+# Copyright 2023 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+# Fluentbit configuration
+fluent_bit_configuration_file: "{{ ranger_adm_conf_dir }}/ranger-admin-fluent-bit.conf"
+fluent_bit_configuration:
+  INPUT:
+    Name: tail
+    Path: "{{ ranger_log_dir }}/ranger-admin-{{ ansible_fqdn }}-{{ ranger_user }}.log"

--- a/tdp_vars_defaults/ranger/ranger_admin.yml
+++ b/tdp_vars_defaults/ranger/ranger_admin.yml
@@ -1,4 +1,4 @@
-# Copyright 2023 TOSIT.IO
+# Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
 ---

--- a/tdp_vars_defaults/ranger/ranger_kms.yml
+++ b/tdp_vars_defaults/ranger/ranger_kms.yml
@@ -18,3 +18,10 @@ kms_site:
   hadoop.kms.proxyuser.yarn.hosts: '*'
   hadoop.kms.proxyuser.hive.groups: '*'
   hadoop.kms.proxyuser.hive.hosts: '*'
+
+# Fluentbit configuration
+fluent_bit_configuration_file: "{{ ranger_kms_conf_dir }}/ranger-kms-fluent-bit.conf"
+fluent_bit_configuration:
+  INPUT:
+    Name: tail
+    Path: "{{ ranger_kms_log_dir }}/ranger-kms-{{ ansible_fqdn }}-{{ ranger_kms_user }}.log"

--- a/tdp_vars_defaults/ranger/ranger_usersync.yml
+++ b/tdp_vars_defaults/ranger/ranger_usersync.yml
@@ -1,0 +1,10 @@
+# Copyright 2023 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+# Fluentbit configuration
+fluent_bit_configuration_file: "/etc/ranger/usersync/conf/ranger-usersync-fluent-bit.conf"
+fluent_bit_configuration:
+  INPUT:
+    Name: tail
+    Path: "{{ ranger_usersync_log_dir }}/usersync-{{ ansible_fqdn }}-{{ ranger_user }}.log"

--- a/tdp_vars_defaults/ranger/ranger_usersync.yml
+++ b/tdp_vars_defaults/ranger/ranger_usersync.yml
@@ -1,4 +1,4 @@
-# Copyright 2023 TOSIT.IO
+# Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
 ---

--- a/tdp_vars_defaults/spark/spark_historyserver.yml
+++ b/tdp_vars_defaults/spark/spark_historyserver.yml
@@ -1,0 +1,10 @@
+# Copyright 2023 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+# Fluentbit configuration
+fluent_bit_configuration_file: "{{ spark_hs_conf_dir }}/spark-hs-fluent-bit.conf"
+fluent_bit_configuration:
+  INPUT:
+    Name: tail
+    Path: "{{ spark_log_dir }}/spark-{{ spark_user }}-org.apache.spark.deploy.history.HistoryServer-1-{{ ansible_fqdn }}.out"

--- a/tdp_vars_defaults/spark/spark_historyserver.yml
+++ b/tdp_vars_defaults/spark/spark_historyserver.yml
@@ -1,4 +1,4 @@
-# Copyright 2023 TOSIT.IO
+# Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
 ---

--- a/tdp_vars_defaults/spark3/spark3_historyserver.yml
+++ b/tdp_vars_defaults/spark3/spark3_historyserver.yml
@@ -1,0 +1,10 @@
+# Copyright 2023 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+# Fluentbit configuration
+fluent_bit_configuration_file: "{{ spark_hs_conf_dir }}/spark3-hs-fluent-bit.conf"
+fluent_bit_configuration:
+  INPUT:
+    Name: tail
+    Path: "{{ spark_log_dir }}/spark-{{ spark_user }}-org.apache.spark.deploy.history.HistoryServer-1-{{ ansible_fqdn }}.out"

--- a/tdp_vars_defaults/spark3/spark3_historyserver.yml
+++ b/tdp_vars_defaults/spark3/spark3_historyserver.yml
@@ -1,4 +1,4 @@
-# Copyright 2023 TOSIT.IO
+# Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
 ---

--- a/tdp_vars_defaults/yarn/yarn_apptimelineserver.yml
+++ b/tdp_vars_defaults/yarn/yarn_apptimelineserver.yml
@@ -1,0 +1,10 @@
+# Copyright 2023 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+# Fluentbit configuration
+fluent_bit_configuration_file: "{{ hadoop_ats_conf_dir }}/yarn-ats-fluent-bit.conf"
+fluent_bit_configuration:
+  INPUT:
+    Name: tail
+    Path: "{{ hadoop_yarn_log_dir }}/hadoop-{{ yarn_user }}-timelineserver-{{ ansible_fqdn }}.log"

--- a/tdp_vars_defaults/yarn/yarn_apptimelineserver.yml
+++ b/tdp_vars_defaults/yarn/yarn_apptimelineserver.yml
@@ -1,4 +1,4 @@
-# Copyright 2023 TOSIT.IO
+# Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
 ---

--- a/tdp_vars_defaults/yarn/yarn_jobhistoryserver.yml
+++ b/tdp_vars_defaults/yarn/yarn_jobhistoryserver.yml
@@ -1,0 +1,10 @@
+# Copyright 2023 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+# Fluentbit configuration
+fluent_bit_configuration_file: "{{ hadoop_jhs_conf_dir }}/yarn-jhs-fluent-bit.conf"
+fluent_bit_configuration:
+  INPUT:
+    Name: tail
+    Path: "{{ hadoop_mapred_log_dir }}/hadoop-{{ mapred_user }}-historyserver-{{ ansible_fqdn }}.log"

--- a/tdp_vars_defaults/yarn/yarn_jobhistoryserver.yml
+++ b/tdp_vars_defaults/yarn/yarn_jobhistoryserver.yml
@@ -1,4 +1,4 @@
-# Copyright 2023 TOSIT.IO
+# Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
 ---

--- a/tdp_vars_defaults/yarn/yarn_nodemanager.yml
+++ b/tdp_vars_defaults/yarn/yarn_nodemanager.yml
@@ -1,0 +1,10 @@
+# Copyright 2023 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+# Fluentbit configuration
+fluent_bit_configuration_file: "{{ hadoop_nm_conf_dir }}/yarn-nm-fluent-bit.conf"
+fluent_bit_configuration:
+  INPUT:
+    Name: tail
+    Path: "{{ hadoop_yarn_log_dir }}/hadoop-{{ yarn_user }}-nodemanager-{{ ansible_fqdn }}.log"

--- a/tdp_vars_defaults/yarn/yarn_nodemanager.yml
+++ b/tdp_vars_defaults/yarn/yarn_nodemanager.yml
@@ -1,4 +1,4 @@
-# Copyright 2023 TOSIT.IO
+# Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
 ---

--- a/tdp_vars_defaults/yarn/yarn_resourcemanager.yml
+++ b/tdp_vars_defaults/yarn/yarn_resourcemanager.yml
@@ -4,3 +4,10 @@
 ---
 yarn_site:
   yarn.resourcemanager.nodes.exclude-path: "{{ hadoop_rm_conf_dir }}/yarn.exclude"
+
+# Fluentbit configuration
+fluent_bit_configuration_file: "{{ hadoop_rm_conf_dir }}/yarn-rm-fluent-bit.conf"
+fluent_bit_configuration:
+  INPUT:
+    Name: tail
+    Path: "{{ hadoop_yarn_log_dir }}/hadoop-{{ yarn_user }}-resourcemanager-{{ ansible_fqdn }}.log"

--- a/tdp_vars_defaults/zookeeper/zookeeper_server.yml
+++ b/tdp_vars_defaults/zookeeper/zookeeper_server.yml
@@ -1,0 +1,10 @@
+# Copyright 2023 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+# Fluentbit configuration
+fluent_bit_configuration_file: "{{ zookeeper_server_conf_dir }}/zookeeper-server-fluent-bit.conf"
+fluent_bit_configuration:
+  INPUT:
+    Name: tail
+    Path: "{{ zookeeper_log_dir }}/{{ zookeeper_log_file }}"

--- a/tdp_vars_defaults/zookeeper/zookeeper_server.yml
+++ b/tdp_vars_defaults/zookeeper/zookeeper_server.yml
@@ -1,4 +1,4 @@
-# Copyright 2023 TOSIT.IO
+# Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
 ---


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #613 

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

This PR adds a `configuration` step to each service in which we template a valid Fluentbit configuration file to tail the service's logs.

Example for `hbase_master`:

```
[INPUT]
    Name tail
    Path /var/log/hbase/hbase-hbase-master-master01.tdp.log
```

I did not variabilize the ability to disable the creation of the file since it's the user's job to include these config in a Fluentbit configuration file (can be done with https://github.com/TOSIT-IO/tdp-collection-prerequisites/pull/63). The `SERVICE-COMPONENT-fluent-bit.conf` do nothing on their own.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
