### PR TITLE
180 make hive jceks updatable

### DIFF
--- a/roles/hive/metastore/tasks/config.yml
+++ b/roles/hive/metastore/tasks/config.yml
@@ -14,20 +14,16 @@
     - backup
 
 - name: Create hive credentials store
-  command: >-
-    {{ hadoop_home }}/bin/hadoop credential
-    create javax.jdo.option.ConnectionPassword
-    -value '{{ hive_ms_db_password }}'
-    -provider {{ hive_ms_credentials_store_uri }}
-  args:
-    creates: "{{ hive_ms_credentials_store_path }}"
-  no_log: true
-
-- name: Ensure hive credentials store is 600 and owned by hive
-  file:
-    path: "{{ hive_ms_credentials_store_path }}"
+  import_role:
+    name: tosit.tdp.utils.jceks
+    tasks_from: local
+  vars:
+    jceks_file: "{{ hive_ms_credentials_store_path }}"
     mode: "600"
     owner: "{{ hive_user }}"
+    properties:
+      - property: javax.jdo.option.ConnectionPassword
+        value: "{{ hive_ms_db_password }}"
 
 - name: Template hive-env.sh
   template:

--- a/roles/utils/jceks/defaults/main.yml
+++ b/roles/utils/jceks/defaults/main.yml
@@ -1,0 +1,6 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+hadoop_home: "/opt/tdp/hadoop"
+hadoop_credstore_password: "none"

--- a/roles/utils/jceks/tasks/local.yml
+++ b/roles/utils/jceks/tasks/local.yml
@@ -1,0 +1,25 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: "Remove previous JCEKS file {{ jceks_file }}"
+  file:
+    path: "{{ jceks_file }}"
+    state: absent
+
+- name: "Create JCEKS file {{ jceks_file }}"
+  command: >-
+    {{ hadoop_home }}/bin/hadoop credential
+    create {{ item.property }}
+    -value '{{ item.value }}'
+    -provider localjceks://file{{ jceks_file }}
+  environment:
+    HADOOP_CREDSTORE_PASSWORD: "{{ hadoop_credstore_password }}"
+  loop: "{{ properties }}"
+  no_log: true
+
+- name: "Ensure {{ jceks_file }} permissions / owner"
+  file:
+    path: "{{ hive_ms_credentials_store_path }}"
+    mode: "{{ mode }}"
+    owner: "{{ owner }}"


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #180 

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

Here is my proposal for allowing JCEKS files update and its implementation with Hive.

The role supports using a different password than the default `none` (via the `HADOOP_CREDSTORE_PASSWORD` env var).

We can also add multiple entries to the JCEKS file with:

```
    properties:
      - property: key1
        value: value1
      - property: key2
        value: value2
```

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
