### PR TITLE
387 hadoop credential for password

### DIFF
--- a/roles/hbase/master/tasks/ssl-tls.yml
+++ b/roles/hbase/master/tasks/ssl-tls.yml
@@ -10,6 +10,16 @@
     group: root
     mode: "644"
 
+- name: Create hadoop credentials store
+  import_role:
+    name: tosit.tdp.utils.jceks
+    tasks_from: local
+  vars:
+    jceks_file: "{{ hbase_master_conf_dir }}/{{ hadoop_credentials_store_file }}"
+    mode: "600"
+    owner: "{{ hbase_user }}"
+    properties: "{{ hadoop_credentials_properties }}"
+
 - name: Ensure hbase keystore exists
   include_role:
     name: tosit.tdp.utils.ssl_tls

--- a/roles/hbase/phoenix/queryserver/daemon/tasks/ssl-tls.yml
+++ b/roles/hbase/phoenix/queryserver/daemon/tasks/ssl-tls.yml
@@ -2,6 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
+- name: Create hadoop credentials store
+  import_role:
+    name: tosit.tdp.utils.jceks
+    tasks_from: local
+  vars:
+    jceks_file: "{{ hbase_phoenix_queryserver_daemon_conf_dir }}/{{ hadoop_credentials_store_file }}"
+    mode: "600"
+    owner: "{{ phoenix_queryserver_user }}"
+    properties: "{{ hadoop_credentials_properties }}"
+
 - name: Ensure phoenix queryserver keystore exists
   include_role:
     name: tosit.tdp.utils.ssl_tls

--- a/roles/hbase/regionserver/tasks/ssl-tls.yml
+++ b/roles/hbase/regionserver/tasks/ssl-tls.yml
@@ -10,6 +10,16 @@
     group: root
     mode: "644"
 
+- name: Create hadoop credentials store
+  import_role:
+    name: tosit.tdp.utils.jceks
+    tasks_from: local
+  vars:
+    jceks_file: "{{ hbase_rs_conf_dir }}/{{ hadoop_credentials_store_file }}"
+    mode: "600"
+    owner: "{{ hbase_user }}"
+    properties: "{{ hadoop_credentials_properties }}"
+
 - name: Ensure hbase keystore exists
   include_role:
     name: tosit.tdp.utils.ssl_tls

--- a/roles/hbase/rest/tasks/ssl-tls.yml
+++ b/roles/hbase/rest/tasks/ssl-tls.yml
@@ -2,13 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-- name: Render ssl-server.xml
-  template:
-    src: hbase/ssl-server.xml.j2
-    dest: "{{ hbase_rest_conf_dir }}/ssl-server.xml"
-    owner: root
-    group: root
-    mode: "644"
+- name: Create hadoop credentials store
+  import_role:
+    name: tosit.tdp.utils.jceks
+    tasks_from: local
+  vars:
+    jceks_file: "{{ hbase_rest_conf_dir }}/{{ hadoop_credentials_store_file }}"
+    mode: "600"
+    owner: "{{ hbase_user }}"
+    properties: "{{ hadoop_credentials_properties }}"
 
 - name: Ensure hbase keystore exists
   include_role:

--- a/roles/hdfs/common/templates/httpfs-env.sh.j2
+++ b/roles/hdfs/common/templates/httpfs-env.sh.j2
@@ -46,18 +46,6 @@ export HTTPFS_HTTP_PORT={{ hdfs_httpfs_port }}
 #
 # export HTTPFS_MAX_HTTP_HEADER_SIZE=65536
 
-# Whether SSL is enabled
-#
-export HTTPFS_SSL_ENABLED={{ httpfs_ssl_enabled }}
-
-# The location of the SSL keystore if using SSL
-#
-export HTTPFS_SSL_KEYSTORE_FILE={{ hadoop_keystore_location }}
-
-# The password of the SSL keystore if using SSL
-#
-export HTTPFS_SSL_KEYSTORE_PASS={{ hadoop_keystore_password }}
-
 export JMX_OPTS="{{ jmx_common_opts }} -Dcom.sun.management.jmxremote.password.file={{ hadoop_httpfs_conf_dir }}/jmxremote.password {{ jmx_exporter_httpfs_opts }}"
 
 export HADOOP_OPTS="$HADOOP_OPTS $JMX_OPTS"

--- a/roles/hdfs/datanode/tasks/ssl-tls.yml
+++ b/roles/hdfs/datanode/tasks/ssl-tls.yml
@@ -10,6 +10,16 @@
     group: root
     mode: "644"
 
+- name: Create hadoop credentials store
+  import_role:
+    name: tosit.tdp.utils.jceks
+    tasks_from: local
+  vars:
+    jceks_file: "{{ hadoop_dn_conf_dir }}/{{ hadoop_credentials_store_file }}"
+    mode: "600"
+    owner: "{{ hdfs_user }}"
+    properties: "{{ hadoop_credentials_properties }}"
+
 - name: Ensure hdfs keystore exists
   include_role:
     name: tosit.tdp.utils.ssl_tls

--- a/roles/hdfs/httpfs/tasks/ssl-tls.yml
+++ b/roles/hdfs/httpfs/tasks/ssl-tls.yml
@@ -10,6 +10,16 @@
     group: root
     mode: "644"
 
+- name: Create hadoop credentials store
+  import_role:
+    name: tosit.tdp.utils.jceks
+    tasks_from: local
+  vars:
+    jceks_file: "{{ hadoop_httpfs_conf_dir }}/{{ hadoop_credentials_store_file }}"
+    mode: "600"
+    owner: "{{ hdfs_user }}"
+    properties: "{{ hadoop_credentials_properties }}"
+
 - name: Ensure httpfs keystore exists
   include_role:
     name: tosit.tdp.utils.ssl_tls

--- a/roles/hdfs/journalnode/tasks/ssl-tls.yml
+++ b/roles/hdfs/journalnode/tasks/ssl-tls.yml
@@ -10,6 +10,16 @@
     group: root
     mode: "644"
 
+- name: Create hadoop credentials store
+  import_role:
+    name: tosit.tdp.utils.jceks
+    tasks_from: local
+  vars:
+    jceks_file: "{{ hadoop_jn_conf_dir }}/{{ hadoop_credentials_store_file }}"
+    mode: "600"
+    owner: "{{ hdfs_user }}"
+    properties: "{{ hadoop_credentials_properties }}"
+
 - name: Ensure hdfs keystore exists
   include_role:
     name: tosit.tdp.utils.ssl_tls

--- a/roles/hdfs/namenode/tasks/ssl-tls.yml
+++ b/roles/hdfs/namenode/tasks/ssl-tls.yml
@@ -18,6 +18,16 @@
     group: root
     mode: "644"
 
+- name: Create hadoop credentials store
+  import_role:
+    name: tosit.tdp.utils.jceks
+    tasks_from: local
+  vars:
+    jceks_file: "{{ hadoop_nn_conf_dir }}/{{ hadoop_credentials_store_file }}"
+    mode: "600"
+    owner: "{{ hdfs_user }}"
+    properties: "{{ hadoop_credentials_properties }}"
+
 - name: Ensure hdfs keystore exists
   include_role:
     name: tosit.tdp.utils.ssl_tls

--- a/roles/spark/historyserver/tasks/ssl-tls.yml
+++ b/roles/spark/historyserver/tasks/ssl-tls.yml
@@ -2,6 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
+- name: Create hadoop credentials store
+  import_role:
+    name: tosit.tdp.utils.jceks
+    tasks_from: local
+  vars:
+    jceks_file: "{{ spark_hs_conf_dir }}/{{ hadoop_credentials_store_file }}"
+    mode: "600"
+    owner: "{{ spark_user }}"
+    properties: "{{ hadoop_credentials_properties }}"
+
 - name: Ensure spark keystore exists
   include_role:
     name: tosit.tdp.utils.ssl_tls

--- a/roles/utils/jceks/tasks/local.yml
+++ b/roles/utils/jceks/tasks/local.yml
@@ -15,6 +15,7 @@
     -provider localjceks://file{{ jceks_file }}
   environment:
     HADOOP_CREDSTORE_PASSWORD: "{{ hadoop_credstore_password }}"
+    JAVA_HOME: "{{ java_home }}"
   loop: "{{ properties }}"
   no_log: true
 

--- a/roles/yarn/apptimelineserver/tasks/ssl-tls.yml
+++ b/roles/yarn/apptimelineserver/tasks/ssl-tls.yml
@@ -10,6 +10,16 @@
     group: root
     mode: "644"
 
+- name: Create hadoop credentials store
+  import_role:
+    name: tosit.tdp.utils.jceks
+    tasks_from: local
+  vars:
+    jceks_file: "{{ hadoop_ats_conf_dir }}/{{ hadoop_credentials_store_file }}"
+    mode: "600"
+    owner: "{{ yarn_user }}"
+    properties: "{{ hadoop_credentials_properties }}"
+
 - name: Ensure yarn keystore exists
   include_role:
     name: tosit.tdp.utils.ssl_tls

--- a/roles/yarn/jobhistoryserver/tasks/ssl-tls.yml
+++ b/roles/yarn/jobhistoryserver/tasks/ssl-tls.yml
@@ -18,6 +18,16 @@
     group: root
     mode: "644"
 
+- name: Create hadoop credentials store
+  import_role:
+    name: tosit.tdp.utils.jceks
+    tasks_from: local
+  vars:
+    jceks_file: "{{ hadoop_jhs_conf_dir }}/{{ hadoop_credentials_store_file }}"
+    mode: "600"
+    owner: "{{ mapred_user }}"
+    properties: "{{ hadoop_credentials_properties }}"
+
 - name: Ensure yarn keystore exists
   include_role:
     name: tosit.tdp.utils.ssl_tls

--- a/roles/yarn/nodemanager/tasks/ssl-tls.yml
+++ b/roles/yarn/nodemanager/tasks/ssl-tls.yml
@@ -10,6 +10,16 @@
     group: root
     mode: "644"
 
+- name: Create hadoop credentials store
+  import_role:
+    name: tosit.tdp.utils.jceks
+    tasks_from: local
+  vars:
+    jceks_file: "{{ hadoop_nm_conf_dir }}/{{ hadoop_credentials_store_file }}"
+    mode: "600"
+    owner: "{{ yarn_user }}"
+    properties: "{{ hadoop_credentials_properties }}"
+
 - name: Ensure yarn keystore exists
   include_role:
     name: tosit.tdp.utils.ssl_tls

--- a/roles/yarn/resourcemanager/tasks/ssl-tls.yml
+++ b/roles/yarn/resourcemanager/tasks/ssl-tls.yml
@@ -18,6 +18,16 @@
     group: root
     mode: "644"
 
+- name: Create hadoop credentials store
+  import_role:
+    name: tosit.tdp.utils.jceks
+    tasks_from: local
+  vars:
+    jceks_file: "{{ hadoop_rm_conf_dir }}/{{ hadoop_credentials_store_file }}"
+    mode: "600"
+    owner: "{{ yarn_user }}"
+    properties: "{{ hadoop_credentials_properties }}"
+
 - name: Ensure yarn keystore exists
   include_role:
     name: tosit.tdp.utils.ssl_tls

--- a/tdp_vars_defaults/hadoop/hadoop.yml
+++ b/tdp_vars_defaults/hadoop/hadoop.yml
@@ -83,17 +83,20 @@ hadoop_truststore_password: Truststore123!
 
 ssl_server:
   ssl.server.keystore.location: "{{ hadoop_keystore_location }}"
-  ssl.server.keystore.password: "{{ hadoop_keystore_password }}"
-  # ssl.server.keystore.keypassword: "{{ hadoop_keystore_password }}"
   ssl.server.truststore.location: "{{ hadoop_truststore_location }}"
-  ssl.server.truststore.password: "{{ hadoop_truststore_password }}"
 
 ssl_client:
-  # ssl.client.keystore.location: "{{ hadoop_keystore_location }}"
-  # ssl.client.keystore.password: "{{ hadoop_keystore_password }}"
-  # ssl.client.keystore.keypassword: "{{ hadoop_keystore_password }}"
   ssl.client.truststore.location: "{{ hadoop_truststore_location }}"
-  ssl.client.truststore.password: "{{ hadoop_truststore_password }}"
+
+# Hadoop credentials
+hadoop_credentials_store_file: hadoop.jceks
+hadoop_credentials_properties:
+  - property: ssl.server.keystore.password
+    value: '{{ hadoop_keystore_password }}'
+  - property: ssl.server.truststore.password
+    value: '{{ hadoop_truststore_password }}'
+  - property: ssl.client.truststore.password
+    value: '{{ hadoop_truststore_password }}'
 
 # SPNEGO Configuration
 http_secret_location: /etc/security/http_secret

--- a/tdp_vars_defaults/hbase/hbase.yml
+++ b/tdp_vars_defaults/hbase/hbase.yml
@@ -64,9 +64,15 @@ hbase_truststore_password: Truststore123!
 
 ssl_server:
   ssl.server.keystore.location: "{{ hbase_keystore_location }}"
-  ssl.server.keystore.password: "{{ hbase_keystore_password }}"
   ssl.server.truststore.location: "{{ hbase_truststore_location }}"
-  ssl.server.truststore.password: "{{ hbase_truststore_password }}"
+
+# Hadoop credentials
+hadoop_credentials_store_file: hbase.jceks
+hadoop_credentials_properties:
+  - property: ssl.server.keystore.password
+    value: "{{ hbase_keystore_password }}"
+  - property: ssl.server.truststore.password
+    value: "{{ hbase_truststore_password }}"
 
 # Properties
 java_home: /usr/lib/jvm/jre-1.8.0-openjdk
@@ -108,7 +114,6 @@ hbase_site:
   hbase.rest.support.proxyuser: "true"
   hbase.rest.ssl.enabled: "true"
   hbase.rest.ssl.keystore.store: "{{ hbase_keystore_location }}"
-  hbase.rest.ssl.keystore.password: "{{ hbase_keystore_password }}"
   hbase.rest.port: "{{ hbase_rest_https_port }}"
   hbase.rest.info.port: "{{ hbase_rest_info_https_port }}"
   hbase.coprocessor.region.classes: org.apache.hadoop.hbase.security.token.TokenProvider

--- a/tdp_vars_defaults/hbase/hbase_master.yml
+++ b/tdp_vars_defaults/hbase/hbase_master.yml
@@ -1,0 +1,6 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+ssl_server:
+  hadoop.security.credential.provider.path: localjceks://file{{ hbase_master_conf_dir }}/{{ hadoop_credentials_store_file }}

--- a/tdp_vars_defaults/hbase/hbase_regionserver.yml
+++ b/tdp_vars_defaults/hbase/hbase_regionserver.yml
@@ -1,0 +1,6 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+ssl_server:
+  hadoop.security.credential.provider.path: localjceks://file{{ hbase_rs_conf_dir }}/{{ hadoop_credentials_store_file }}

--- a/tdp_vars_defaults/hbase/hbase_rest.yml
+++ b/tdp_vars_defaults/hbase/hbase_rest.yml
@@ -5,5 +5,5 @@
 hadoop_credentials_properties:
   - property: hbase.rest.ssl.keystore.password
     value: "{{ hbase_keystore_password }}"
-ssl_server:
+hbase_site:
   hadoop.security.credential.provider.path: localjceks://file{{ hbase_rest_conf_dir }}/{{ hadoop_credentials_store_file }}

--- a/tdp_vars_defaults/hbase/hbase_rest.yml
+++ b/tdp_vars_defaults/hbase/hbase_rest.yml
@@ -1,0 +1,9 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+hadoop_credentials_properties:
+  - property: hbase.rest.ssl.keystore.password
+    value: "{{ hbase_keystore_password }}"
+ssl_server:
+  hadoop.security.credential.provider.path: localjceks://file{{ hbase_rest_conf_dir }}/{{ hadoop_credentials_store_file }}

--- a/tdp_vars_defaults/hbase/phoenix_queryserver_daemon.yml
+++ b/tdp_vars_defaults/hbase/phoenix_queryserver_daemon.yml
@@ -1,0 +1,11 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+hadoop_credentials_properties:
+  - property: phoenix.queryserver.tls.keystore.password
+    value: "{{ hbase_keystore_password }}"
+  - property: phoenix.queryserver.tls.truststore.password
+    value: "{{ hbase_truststore_password }}"
+hbase_site:
+  hadoop.security.credential.provider.path: localjceks://file{{ hbase_phoenix_queryserver_daemon_conf_dir }}/{{ hadoop_credentials_store_file }}

--- a/tdp_vars_defaults/hdfs/hdfs_datanode.yml
+++ b/tdp_vars_defaults/hdfs/hdfs_datanode.yml
@@ -1,0 +1,6 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+ssl_server:
+  hadoop.security.credential.provider.path: localjceks://file{{ hadoop_dn_conf_dir }}/{{ hadoop_credentials_store_file }}

--- a/tdp_vars_defaults/hdfs/hdfs_httpfs.yml
+++ b/tdp_vars_defaults/hdfs/hdfs_httpfs.yml
@@ -24,3 +24,6 @@ httpfs_site:
   httpfs.proxyuser.hue.groups: '*'
   httpfs.proxyuser.hdfs.hosts: '*'
   httpfs.proxyuser.hdfs.groups: '*'
+  httpfs.ssl.enabled: true
+ssl_server:
+  hadoop.security.credential.provider.path: localjceks://file{{ hadoop_httpfs_conf_dir }}/{{ hadoop_credentials_store_file }}

--- a/tdp_vars_defaults/hdfs/hdfs_journalnode.yml
+++ b/tdp_vars_defaults/hdfs/hdfs_journalnode.yml
@@ -1,0 +1,6 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+ssl_server:
+  hadoop.security.credential.provider.path: localjceks://file{{ hadoop_jn_conf_dir }}/{{ hadoop_credentials_store_file }}

--- a/tdp_vars_defaults/hdfs/hdfs_namenode.yml
+++ b/tdp_vars_defaults/hdfs/hdfs_namenode.yml
@@ -4,3 +4,5 @@
 ---
 hdfs_site:
   dfs.hosts.exclude: "{{ hadoop_nn_conf_dir }}/dfs.exclude"
+ssl_server:
+  hadoop.security.credential.provider.path: localjceks://file{{ hadoop_nn_conf_dir }}/{{ hadoop_credentials_store_file }}

--- a/tdp_vars_defaults/spark3/spark3.yml
+++ b/tdp_vars_defaults/spark3/spark3.yml
@@ -49,6 +49,12 @@ spark_keystore_password: Keystore123!
 spark_truststore_location: /etc/ssl/certs/truststore.jks
 spark_truststore_password: Truststore123!
 
+# Hadoop credentials
+hadoop_credentials_store_file: spark.jceks
+hadoop_credentials_properties:
+  - property: spark.ssl.historyServer.keyStorePassword
+    value: '{{ spark_keystore_password }}'
+
 # Spark History Server kerberos
 spark_ui_spnego_principal: "HTTP/{{ ansible_fqdn }}@{{ realm }}"
 spark_ui_spnego_keytab: /etc/security/keytabs/spnego.service.keytab
@@ -124,11 +130,11 @@ spark_defaults_hs:
   spark.org.apache.hadoop.security.authentication.server.AuthenticationFilter.params: type=kerberos,kerberos.principal={{ spark_ui_spnego_principal }},kerberos.keytab={{ spark_ui_spnego_keytab }},cookie.domain={{ http_cookie_domain }},signature.secret.file={{ http_secret_location }}
   spark.ssl.historyServer.enabled: "true"
   spark.ssl.historyServer.keyStore: "{{ spark_keystore_location }}"
-  spark.ssl.historyServer.keyStorePassword: "{{ spark_keystore_password }}"
   spark.ssl.historyServer.port: "{{ spark3_hs_https_port }}"
   spark.history.fs.logDirectory: "hdfs://{{ cluster_name }}/spark3-logs"
   spark.history.provider: org.apache.spark.deploy.history.FsHistoryProvider
   spark.ui.proxyBase: "{% if 'knox' in groups and groups['knox'] %}/gateway/tdpldap/spark3history{% endif %}"
+  spark.hadoop.hadoop.security.credential.provider.path: localjceks://file{{ spark_hs_conf_dir }}/{{ hadoop_credentials_store_file }}
 
 # spark-env.sh - common
 spark_env_common:

--- a/tdp_vars_defaults/yarn/yarn_apptimelineserver.yml
+++ b/tdp_vars_defaults/yarn/yarn_apptimelineserver.yml
@@ -5,4 +5,4 @@
 yarn_site:
   yarn.resourcemanager.nodes.exclude-path: "{{ hadoop_rm_conf_dir }}/yarn.exclude"
 ssl_server:
-  hadoop.security.credential.provider.path: localjceks://file{{ hadoop_rm_conf_dir }}/{{ hadoop_credentials_store_file }}
+  hadoop.security.credential.provider.path: localjceks://file{{ hadoop_ats_conf_dir }}/{{ hadoop_credentials_store_file }}

--- a/tdp_vars_defaults/yarn/yarn_mapred_jobhistoryserver.yml
+++ b/tdp_vars_defaults/yarn/yarn_mapred_jobhistoryserver.yml
@@ -5,4 +5,4 @@
 yarn_site:
   yarn.resourcemanager.nodes.exclude-path: "{{ hadoop_rm_conf_dir }}/yarn.exclude"
 ssl_server:
-  hadoop.security.credential.provider.path: localjceks://file{{ hadoop_rm_conf_dir }}/{{ hadoop_credentials_store_file }}
+  hadoop.security.credential.provider.path: localjceks://file{{ hadoop_jhs_conf_dir }}/{{ hadoop_credentials_store_file }}

--- a/tdp_vars_defaults/yarn/yarn_nodemanager.yml
+++ b/tdp_vars_defaults/yarn/yarn_nodemanager.yml
@@ -1,0 +1,6 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+ssl_server:
+  hadoop.security.credential.provider.path: localjceks://file{{ hadoop_nm_conf_dir }}/{{ hadoop_credentials_store_file }}


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #387 

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

Some remarks:

- `hadoop.security.credential.provider.path` is a `core-site.xml` property but I chose not to put it in the `core_site` dict since it is only copied from hadoop/client and not rendered for all services. I also think it makes more sense to put the store path in the site of the properties it holds (`ssl-server.xml` most of the time, `hbase-site.xml` for HBase REST).
- I also chose this to have a different credential store per component so we can still have different truststore / keystore files if needed.
- Hadoop HttpFs was using SSL through env vars. I switched to properties stored in `ssl-server.xml`.
- I removed the `ssl-server.xml` of HBase REST since it was useless.
- I did not implement the Hadoop credentials file in Spark 2 since our version is lacking the support for this [SPARK-24518](https://issues.apache.org/jira/browse/SPARK-24518).

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
