### PR TITLE
 feat: add hbck2 jar on hbase client install 

### DIFF
--- a/roles/hbase/client/tasks/install.yml
+++ b/roles/hbase/client/tasks/install.yml
@@ -22,3 +22,12 @@
     owner: root
     group: root
     mode: "755"
+
+- name: Upload {{ hbase_hbck2_file }}
+  copy:
+    src: files/{{ hbase_hbck2_file }}
+    dest: "{{ hbase_root_dir }}/{{ hbase_release }}/lib/{{ hbase_hbck2_file }}"
+    owner: root
+    group: root
+    mode: "755"
+  diff: false

--- a/roles/hbase/common/templates/hbase/hbase-env.sh.j2
+++ b/roles/hbase/common/templates/hbase/hbase-env.sh.j2
@@ -93,6 +93,8 @@ export HBASE_REGIONSERVER_OPTS="$HBASE_REGIONSERVER_OPTS -Xmx{{ hbase_rs_heapsiz
 export HBASE_REST_LOGS_OPTS="-Dtdp.hbase.log.file={{ hbase_hr_log_file }}"
 export HBASE_REST_OPTS="$HBASE_REST_OPTS -Xmx{{ hbase_rest_heapsize }} $HBASE_JMX_BASE {{ jmx_exporter_hr_opts }} ${HBASE_REST_LOGS_OPTS}"
 
+# Available since HBASE-26146
+export HBASE_HBCK_OPTS=" "
 
 # File naming hosts on which HRegionServers will run.  $HBASE_HOME/conf/regionservers by default.
 # export HBASE_REGIONSERVERS=${HBASE_HOME}/conf/regionservers

--- a/tdp_vars_defaults/hbase/hbase.yml
+++ b/tdp_vars_defaults/hbase/hbase.yml
@@ -6,6 +6,10 @@
 hbase_release: hbase-2.1.10-TDP-0.1.0-SNAPSHOT
 hbase_dist_file: "{{ hbase_release }}-bin.tar.gz"
 
+# Hbck2 version
+hbase_hbck2_release: hbase-hbck2-1.1.0-TDP-0.1.0-SNAPSHOT 
+hbase_hbck2_file: "{{ hbase_hbck2_release }}.jar"
+
 # HBase users and group
 hdfs_user: hdfs
 hbase_user: hbase


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes https://github.com/TOSIT-IO/hbase/issues/2

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

I'm really not sure about the change I made on the variable rendering `jmx_exporter_hrs_opts`.

Context: when running `hbase hbck -j /opt/tdp/hbase/lib/hbase-hbck2-1.1.0-TDP-0.1.0-SNAPSHOT.jar`, the jar will look for the file `/etc/jmx-exporter/hrs.yml` since it reads `/etc/hbase/conf/hbase-env.sh`. Since the file is only deployed on RS and not the edge, this raises an error.

The fix is to remove the declaration of this file during the rendering of `hbase-env.sh` when running on an edge.

I think it can cause issues if a node is a RS and a edge as it would render the hbase-env.sh without the JMX exporter. I don't know if  that's a real issue. I'm doing some more tests to see if renders the file correctly for RS but I'm open to suggestions to other ways of fixing this issue

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
