### PR TITLE
fix(spark): integration of sparksql and livy

### DIFF
--- a/tdp_vars_defaults/spark/spark.yml
+++ b/tdp_vars_defaults/spark/spark.yml
@@ -109,7 +109,7 @@ spark_defaults_client:
       map('regex_replace', '^(.*)$', '\1:' + zookeeper_server_client_port | string) |
       list |
       join(',') }}
-  spark.sql.hive.metastore.jars: /opt/tdp/hive/lib/*
+  spark.sql.hive.metastore.jars.path: /opt/tdp/hive/lib/
   # Default number of executors
   spark.executor.instances: 2
   # Default spark am allocated vcores

--- a/tdp_vars_defaults/spark3/spark3.yml
+++ b/tdp_vars_defaults/spark3/spark3.yml
@@ -111,7 +111,7 @@ spark_defaults_client:
       map('regex_replace', '^(.*)$', '\1:' + zookeeper_server_client_port | string) |
       list |
       join(',') }}
-  spark.sql.hive.metastore.jars: /opt/tdp/hive/lib/*
+  spark.sql.hive.metastore.jars.path: /opt/tdp/hive/lib/
   # Default number of executors
   spark.executor.instances: 2
   # Default spark am allocated vcores


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->


#### Additional comments
This PR fixes the error when lauching a sparksql session via livy

`evalue": "java.lang.NoClassDefFoundError: org/apache/hadoop/hive/conf/HiveConf when creating Hive client using classpath: \nPlease make sure that jars for your version of hive and hadoop are included in the paths passed to spark.sql.hive.metastore.jars`

<!-- Example: "I was not sure if it is the right way to do but..." -->



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
