### PR TITLE
fix(yarn rm): rm conf dir owned by root

### DIFF
--- a/roles/yarn/resourcemanager/tasks/install.yml
+++ b/roles/yarn/resourcemanager/tasks/install.yml
@@ -11,8 +11,8 @@
   file:
     path: "{{ hadoop_rm_conf_dir }}"
     state: directory
-    owner: "{{ yarn_user }}"
-    group: "{{ hadoop_group }}"
+    owner: root
+    group: root
     mode: "755"
 
 - name: Template YARN ResourceManager service file


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #727 

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->
This PR fixes the error that can intervene when starting Yarn Node Manager :
```
Caused by: ExitCodeException exitCode=24: File /etc/hadoop/conf.rm must be owned by root, but is owned by 1019
```
This configuration folder was the only one not owned by root.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
