### PR TITLE
feat: render HADOOP_OPTIONAL_TOOLS

### DIFF
--- a/roles/hadoop/common/templates/hadoop-env.sh.j2
+++ b/roles/hadoop/common/templates/hadoop-env.sh.j2
@@ -158,6 +158,7 @@ esac
 # This is a comma delimited list.  It may NOT be overridden via .hadooprc
 # Entries may be added/removed as needed.
 # export HADOOP_OPTIONAL_TOOLS="hadoop-aliyun,hadoop-aws,hadoop-azure-datalake,hadoop-azure,hadoop-kafka,hadoop-openstack"
+export HADOOP_OPTIONAL_TOOLS="{{ hadoop_optional_tools | join(',') }}"
 
 ###
 # Options for remote shell connectivity

--- a/tdp_vars_defaults/hadoop/hadoop.yml
+++ b/tdp_vars_defaults/hadoop/hadoop.yml
@@ -251,3 +251,6 @@ ranger_kms_hosts: |-
   {{ groups['ranger_kms'] |
     map('tosit.tdp.access_fqdn', hostvars) |
     join(';') }}{% else %}NONE{% endif %}
+
+hadoop_optional_tools:
+  - hadoop-aws


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #751 

#### Additional comments

Docs on this : https://effectivemachines.com/2016/08/06/adding-to-apache-hadoops-classpath/

- Java classes can be added to the classpath programatically
- Some modules are available in `hadoop/hadoop-tools` including 
  - hadoop-aws
  - hadoop-azure
  - ...
- One can enable these modules (= adding them to the classpath) with the HADOOP_OPTIONAL_TOOLS env
- In my case I just add hadoop-aws to this variable
  - It then enables the shellprofile hadoop-aws (located in `/opt/tdp/hadoop/libexec/shellprofile.d/hadoop-aws.sh`
  - This shellprofile add hadoop-aws to the classpath
  
#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
