### PR TITLE
fix(zk): do not apply zookeeper install directory permissions recursively

### DIFF
--- a/roles/zookeeper/common/tasks/install.yml
+++ b/roles/zookeeper/common/tasks/install.yml
@@ -46,7 +46,6 @@
   file:
     path: "{{ hadoop_root_dir }}/{{ zookeeper_dist_release }}"
     state: directory
-    recurse: true
     group: root
     owner: root
     mode: "755"


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #754 

#### Additional comments
<!-- Example: "I was not sure if it is the right way to do but..." -->
By removing the `recurse: true` when ensuring `"{{ hadoop_root_dir }}/{{ zookeeper_dist_release }}"` permissions are correct, ZooKeeper instances will still be able to serve requests as the permissions on `{{ hadoop_root_dir }}/{{ zookeeper_dist_release }}/zkData` and underlying paths will remain untouched (`zookeeper:hadoop`) even if `tosit.tdp.meta.zookeeper` is run multiple times.

I made some tests and did not find any regression after removing the `recurse: true`.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
