### PR TITLE
fix: use console appender instead of RFA for hbase client

### DIFF
--- a/tdp_vars_defaults/hbase/hbase_client.yml
+++ b/tdp_vars_defaults/hbase/hbase_client.yml
@@ -1,0 +1,5 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+hbase_root_logger: console


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #757  

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

When using hbase client binaries (hbase shell)

- the HBASE_ROOT_LOGGER env (in `hbase-env.sh`) is set `INFO,RFA` in every hbase module.
- This environment variable is translated and added to HBASE_OPTS in `/opt/tdp/hbase/bin/hbase`
```
HBASE_OPTS="$HBASE_OPTS -Dhbase.root.logger=${HBASE_ROOT_LOGGER:-INFO,console}"
```
- Since the RFA is a RollingFileAppender, log4j tries to write to `/var/log/hbase/hbase.log`
- Using `hbase shell`, the user is not necessarily root nor hbase as it's available on a edge node
- A "Permission Denied" is thrown and shown to the user even though it's just a logging error.

Setting 'console' instead of RFA for hbase_client fixes the issue. Logs are shown directly on the hbase shell (default INFO, which is not very verbose) 

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
