### PR TITLE
776 Remove hardcoded JAVA_HOME in the roles/

### DIFF
--- a/roles/hbase/ranger/tasks/config.yml
+++ b/roles/hbase/ranger/tasks/config.yml
@@ -26,7 +26,7 @@
 
 - name: Run enable-hbase-plugin.sh
   shell: |
-    export JAVA_HOME=/usr/lib/jvm/jre-1.8.0-openjdk
+    export JAVA_HOME={{ java_home }}
     ./enable-hbase-plugin.sh
   args:
     chdir: "{{ ranger_hbase_install_dir }}"

--- a/roles/hdfs/ranger/tasks/config.yml
+++ b/roles/hdfs/ranger/tasks/config.yml
@@ -35,7 +35,7 @@
 
 - name: Run enable-hdfs-plugin.sh
   shell: |
-    export JAVA_HOME=/usr/lib/jvm/jre-1.8.0-openjdk
+    export JAVA_HOME={{ java_home }}
     ./enable-hdfs-plugin.sh
   args:
     chdir: "{{ ranger_hdfs_install_dir }}"

--- a/roles/hive/ranger/tasks/config.yml
+++ b/roles/hive/ranger/tasks/config.yml
@@ -35,7 +35,7 @@
 
 - name: Run enable-hive-plugin.sh
   shell: |
-    export JAVA_HOME=/usr/lib/jvm/jre-1.8.0-openjdk
+    export JAVA_HOME={{ java_home }}
     ./enable-hive-plugin.sh
   args:
     chdir: "{{ ranger_hive_install_dir }}"

--- a/roles/knox/ranger/tasks/config.yml
+++ b/roles/knox/ranger/tasks/config.yml
@@ -36,7 +36,7 @@
 
 - name: Run enable-knox-plugin.sh
   shell: |
-    export JAVA_HOME=/usr/lib/jvm/jre-1.8.0-openjdk
+    export JAVA_HOME={{ java_home }}
     ./enable-knox-plugin.sh
   args:
     chdir: "{{ ranger_knox_install_dir }}"

--- a/roles/ranger/admin/tasks/config.yml
+++ b/roles/ranger/admin/tasks/config.yml
@@ -12,7 +12,7 @@
 
 - name: Run setup.sh
   shell: |
-    export JAVA_HOME=/usr/lib/jvm/jre-1.8.0-openjdk
+    export JAVA_HOME={{ java_home }}
     ./setup.sh
   args:
     chdir: "{{ ranger_install_dir }}"

--- a/roles/ranger/kms/tasks/config.yml
+++ b/roles/ranger/kms/tasks/config.yml
@@ -12,7 +12,7 @@
 
 - name: Run setup.sh
   shell: |
-    export JAVA_HOME=/usr/lib/jvm/jre-1.8.0-openjdk
+    export JAVA_HOME={{ java_home }}
     ./setup.sh
   args:
     chdir: "{{ ranger_kms_install_dir }}"

--- a/roles/ranger/usersync/tasks/config.yml
+++ b/roles/ranger/usersync/tasks/config.yml
@@ -12,7 +12,7 @@
 
 - name: Setup usersync
   shell: |
-    export JAVA_HOME=/usr/lib/jvm/jre-1.8.0-openjdk
+    export JAVA_HOME={{ java_home }}
     export PATH="${JAVA_HOME}/bin:${PATH}"
     {{ python_interpreter }} ./setup.py
   args:

--- a/roles/yarn/ranger/tasks/config.yml
+++ b/roles/yarn/ranger/tasks/config.yml
@@ -36,7 +36,7 @@
 
 - name: Run enable-yarn-plugin.sh
   shell: |
-    export JAVA_HOME=/usr/lib/jvm/jre-1.8.0-openjdk
+    export JAVA_HOME={{ java_home }}
     ./enable-yarn-plugin.sh
   args:
     chdir: "{{ ranger_yarn_install_dir }}"


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #776

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

I kept the "export JAVA_HOME" during each script to keep existing feature. Maybe it is not useful anymore as JAVE_HOME should be defined in globab env var.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions. 