### PR TITLE
yarn: disable vmem-check for better jupyterhub integration

### DIFF
--- a/tdp_vars_defaults/yarn/yarn.yml
+++ b/tdp_vars_defaults/yarn/yarn.yml
@@ -108,6 +108,7 @@ yarn_site:
   yarn.nodemanager.webapp.spnego-principal: "HTTP/_HOST@{{ realm }}"
   # disable vmem-check for better jupyterhub integration
   yarn.nodemanager.vmem-check-enabled: "false"
+  yarn.nodemanager.pmem-check-enabled: "true"
   yarn.nodemanager.vmem-pmem-ratio: 4
   yarn.timeline-service.enabled: "true"
   yarn.timeline-service.generic-application-history.enabled: "true"

--- a/tdp_vars_defaults/yarn/yarn.yml
+++ b/tdp_vars_defaults/yarn/yarn.yml
@@ -106,7 +106,8 @@ yarn_site:
   yarn.nodemanager.keytab: /etc/security/keytabs/nm.service.keytab
   yarn.nodemanager.webapp.spnego-keytab-file: /etc/security/keytabs/spnego.service.keytab
   yarn.nodemanager.webapp.spnego-principal: "HTTP/_HOST@{{ realm }}"
-  # yarn.nodemanager.vmem-check-enabled: "false"
+  # disable vmem-check for better jupyterhub integration
+  yarn.nodemanager.vmem-check-enabled: "false"
   yarn.nodemanager.vmem-pmem-ratio: 4
   yarn.timeline-service.enabled: "true"
   yarn.timeline-service.generic-application-history.enabled: "true"


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->
Fixes #809
disable vmem-check for better jupyterhub integration.
As described in[ this hadoop documentation](https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-site/NodeManagerCGroupsMemory.html), this check can be useful in case of Elastic Memory Control.



#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
