### PR TITLE
fix: timestamp formatting in logs from 12h to 24h

### DIFF
--- a/tdp_vars_defaults/tdp-cluster/tdp-cluster.yml
+++ b/tdp_vars_defaults/tdp-cluster/tdp-cluster.yml
@@ -166,7 +166,7 @@ exporter_hdfs_httpfs_http_port: 18122
 #################################
 # format : log4j 1.x "%d{ISO8601}" is not fully compliant with ISO8601 standard 
 # (no 'T' as date/time separator) we specify it here.
-tdp_date_iso8601_with_tz: "%d{yyyy-MM-dd'T'hh:mm:ss.SSSXXX}"
+tdp_date_iso8601_with_tz: "%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX}"
 tdp_log_layout_pattern: '{{ tdp_date_iso8601_with_tz }} - %-5p [%t:%C{1}@%L] - %m%n'
 
 hadoop_log_dir: /var/log/hadoop


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Comments

Timestamp for hours was coded 'hh' which is hours in am/pm format (0-12)
Loki needs hours from 0 to 23


#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
