### PR TITLE
fix: reestablish hadoop conf link

### DIFF
--- a/roles/hdfs/ranger/tasks/config.yml
+++ b/roles/hdfs/ranger/tasks/config.yml
@@ -39,3 +39,9 @@
     ./enable-hdfs-plugin.sh
   args:
     chdir: "{{ ranger_hdfs_install_dir }}"
+
+- name: Reestablish symbolic link from etc/hadoop in {{ hadoop_install_dir }} to {{ hadoop_client_conf_dir }}
+  ansible.builtin.file:
+    src: "{{ hadoop_client_conf_dir }}"
+    dest: "{{ hadoop_install_dir }}/etc/hadoop"
+    state: link

--- a/roles/yarn/ranger/tasks/config.yml
+++ b/roles/yarn/ranger/tasks/config.yml
@@ -40,3 +40,9 @@
     ./enable-yarn-plugin.sh
   args:
     chdir: "{{ ranger_yarn_install_dir }}"
+
+- name: Reestablish symbolic link from etc/hadoop in {{ hadoop_install_dir }} to {{ hadoop_client_conf_dir }}
+  ansible.builtin.file:
+    src: "{{ hadoop_client_conf_dir }}"
+    dest: "{{ hadoop_install_dir }}/etc/hadoop"
+    state: link


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

Ranger plugin config for hdfs and yarn breaks the symbolic link that was previously created by [hadoop client installation](https://github.com/TOSIT-IO/tdp-collection/blob/2784de6f9df0d40e4713d8026cb7b8fd1a932b47/roles/hadoop/client/tasks/install.yml#L23).

This fix recreates the link back to its original value, after the enable plugin script has run.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
