### PR TITLE
fix: move zkfc systemd template to install

### DIFF
--- a/roles/hdfs/namenode/tasks/config.yml
+++ b/roles/hdfs/namenode/tasks/config.yml
@@ -33,14 +33,6 @@
   vars:
     ranger_audit_file: "{{ hdfs_log_dir }}/{{ hadoop_hdfs_ranger_audit_file }}"
 
-- name: Template HDFS ZKFC service file
-  ansible.builtin.template:
-    src: hadoop-hdfs-zkfc.service.j2
-    dest: /usr/lib/systemd/system/hadoop-hdfs-zkfc.service
-    owner: root
-    group: root
-    mode: "644"
-
 - name: Render core-site.xml
   ansible.builtin.template:
     src: core-site.xml.j2

--- a/roles/hdfs/namenode/tasks/install.yml
+++ b/roles/hdfs/namenode/tasks/install.yml
@@ -32,3 +32,13 @@
     mode: "644"
   notify:
     - systemctl daemon-reload
+
+- name: Template HDFS ZKFC service file
+  ansible.builtin.template:
+    src: hadoop-hdfs-zkfc.service.j2
+    dest: /usr/lib/systemd/system/hadoop-hdfs-zkfc.service
+    owner: root
+    group: root
+    mode: "644"
+  notify:
+    - systemctl daemon-reload


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes Issue not crated

#### Additional comments

ZKFC systemd service template was done in install ops and not in config. Also it did not have a notify attribute for a daemon reload



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
