### PR TITLE
fix(ranger): add whitespace in order to fix templating

### DIFF
--- a/roles/ranger/common/templates/install.properties.j2
+++ b/roles/ranger/common/templates/install.properties.j2
@@ -195,7 +195,7 @@ xa_ldap_ad_userSearchFilter=
 
 #------------ Kerberos Config -----------------
 spnego_principal=HTTP/{% if ranger_ha_address is defined %}{{ ranger_ha_address | urlsplit("hostname") }}{% else %}{{ ansible_fqdn }}{% endif %}@{{ realm }}
-spnego_keytab=/etc/security/keytabs/{% if ranger_ha_address is defined %}{{ ranger_ha_address | urlsplit("hostname") }}.service.keytab{% else %}spnego.service.keytab{% endif %}
+spnego_keytab=/etc/security/keytabs/{% if ranger_ha_address is defined %}{{ ranger_ha_address | urlsplit("hostname") }}.service.keytab{% else %}spnego.service.keytab{% endif %} 
 token_valid=30
 cookie_domain=
 cookie_path=/


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Missing whitespace in install.properties.j2 create issue when ranger templates its site.

Heres an example of what the property is templated to in ranger-admin-site.xml by ranger's setup.sh

```
        <property>
                <name>ranger.spnego.kerberos.keytab</name>
                <value>/etc/security/keytabs/spnego.service.keytabtoken_valid=30</value>
        </property>
```

You can see that this small unfortunate mistake has been introduced by #844 here https://github.com/TOSIT-IO/tdp-collection/pull/844/files#diff-5d5bf852121faeb978b8b79af8454dea1115d35aae78b1803acd53e1608a44d9

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
