### PR TITLE
869 Create ranger_solr_log_dir

### DIFF
--- a/roles/ranger/common/templates/solr_standalone/log4j2.properties.j2
+++ b/roles/ranger/common/templates/solr_standalone/log4j2.properties.j2
@@ -24,8 +24,8 @@ appenders = {{ ranger_root_logger }}
 # rolling file appender
 appender.RFA.type = RollingRandomAccessFile
 appender.RFA.name = RFA
-appender.RFA.fileName = {{ ranger_log_dir }}/{{ ranger_solr_log_file }}
-appender.RFA.filePattern = {{ ranger_log_dir }}/{{ ranger_solr_log_file }}.%i
+appender.RFA.fileName = {{ ranger_solr_log_dir }}/{{ ranger_solr_log_file }}
+appender.RFA.filePattern = {{ ranger_solr_log_dir }}/{{ ranger_solr_log_file }}.%i
 appender.RFA.layout.type = PatternLayout
 appender.RFA.layout.pattern = {{ ranger_log_layout_pattern }}
 appender.RFA.policies.type = Policies
@@ -37,8 +37,8 @@ appender.RFA.strategy.max = {{ ranger_log_rfa_maxbackupindex }}
 # daily rolling file appender
 appender.DRFA.type = RollingRandomAccessFile
 appender.DRFA.name = DRFA
-appender.DRFA.fileName = {{ ranger_log_dir }}/{{ ranger_solr_log_file }}
-appender.DRFA.filePattern = {{ ranger_log_dir }}/{{ ranger_solr_log_file }}.{{ ranger_solr_log_drfa_date_pattern }} 
+appender.DRFA.fileName = {{ ranger_solr_log_dir }}/{{ ranger_solr_log_file }}
+appender.DRFA.filePattern = {{ ranger_solr_log_dir }}/{{ ranger_solr_log_file }}.{{ ranger_solr_log_drfa_date_pattern }} 
 appender.DRFA.layout.type = PatternLayout
 appender.DRFA.layout.pattern = {{ ranger_log_layout_pattern }}
 appender.DRFA.policies.type = Policies

--- a/roles/ranger/common/templates/solr_standalone/solr.service.j2
+++ b/roles/ranger/common/templates/solr_standalone/solr.service.j2
@@ -7,7 +7,7 @@ Wants=network-online.target
 User={{ solr_user }}
 Group={{ hadoop_group }}
 Environment="SOLR_PID_DIR={{ solr_pid_dir }}"
-Environment="SOLR_LOGS_DIR={{ ranger_log_dir }}"
+Environment="SOLR_LOGS_DIR={{ ranger_solr_log_dir }}"
 Environment="LOG4J_PROPS={{ solr_conf_dir }}/log4j2.properties"
 Environment="SOLR_HEAP={{ ranger_solr_heapsize }}"
 Environment="SOLR_DATA_HOME={{ ranger_solr_datadir }}"

--- a/roles/ranger/solr/tasks/install.yml
+++ b/roles/ranger/solr/tasks/install.yml
@@ -96,7 +96,7 @@
 
 - name: Create log directory
   ansible.builtin.file:
-    path: "{{ ranger_log_dir }}"
+    path: "{{ ranger_solr_log_dir }}"
     state: directory
     group: "{{ hadoop_group }}"
     owner: root

--- a/tdp_vars_defaults/tdp-cluster/tdp-cluster.yml
+++ b/tdp_vars_defaults/tdp-cluster/tdp-cluster.yml
@@ -213,6 +213,7 @@ knox_ranger_audit_file: "knox-rangeraudit_{{ ansible_fqdn }}.log"
 ranger_log_dir: /var/log/ranger
 ranger_admin_log_file: "ranger-admin_{{ ansible_fqdn }}.log"
 ranger_usersync_log_file: "ranger-usersync_{{ ansible_fqdn }}.log"
+ranger_solr_log_dir: /var/log/ranger_solr
 ranger_solr_log_file: "ranger-solr_{{ ansible_fqdn }}.log"
 
 ranger_kms_log_dir: /var/log/kms


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #869 

#### Additional comments

There was no ranger_solr_log_dir variable set. Ranger solr logs were located in ranger_log_dir along with ranger admin/kms/usersync... It could be better and it creates issue since ranger's setup.sh set permissions on this dir and create permission issue for ranger.

Note that to add this feature on a running cluster, one must add ranger_solr_log_file in tdp_vars/tdp_cluster

#### Agreements

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions. 