### PR TITLE
fix(knox): livy servers port are hardcoded

### DIFF
--- a/tdp_vars_defaults/knox/knox.yml
+++ b/tdp_vars_defaults/knox/knox.yml
@@ -177,10 +177,10 @@ tdpldap_services:
     port: "{{ hbase_master_info_port }}"
   LIVYSERVER:
     hosts: "{% if groups['livy_server'] is defined %}{{ groups['livy_server'] | default([]) | map('tosit.tdp.access_fqdn', hostvars) | list }}{% else %}{% endif %}"
-    port: "8998"
+    port: "{% if livy_spark2_server_port is defined %}{{ livy_spark2_server_port }}{% else %}8998{% endif %}"
   LIVYSERVER3:
     hosts: "{% if groups['livy_spark3_server'] is defined %}{{ groups['livy_spark3_server'] | default([]) | map('tosit.tdp.access_fqdn', hostvars) | list }}{% else %}{% endif %}"
-    port: "8999"
+    port: "{% if livy_spark3_server_port is defined %}{{ livy_spark3_server_port }}{% else %}8999{% endif %}"
   AVATICA:
     hosts: "{% if groups['phoenix_queryserver_daemon'] is defined %}{{ groups['phoenix_queryserver_daemon'] | default([]) | map('tosit.tdp.access_fqdn', hostvars) | list }}{% else %}{% endif %}"
     port: "{{ phoenix_queryserver_http_port }}"


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes no issue created.

livy server spark2 and spark3 are hard coded.
It was done this way since variables comes from tdp_collection_extras and can be undefined. I added a logic to manage undefined variables. it is not perfect but it fixes the issue of managing undefined variable.

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions. 