### PR TITLE
fix: remove livyserver haprovider

### DIFF
--- a/tdp_vars_defaults/knox/knox.yml
+++ b/tdp_vars_defaults/knox/knox.yml
@@ -136,7 +136,6 @@ tdpldap_ha:
     HBASEUI: "{{ topology_common_ha_configuration }}"
     HDFSUI: "{{ topology_common_ha_configuration }}"
     NAMENODE: "{{ topology_common_ha_configuration }}"
-    LIVYSERVER: "{{ topology_common_ha_configuration }}"
 
 tdpldap_services:
   NAMENODE:


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

One can not expect livyserver haprovider to work out of the box at the moment. There are multiple issues regarding session, recovery of sessinn and HA for session.

It is preferable to remove livyserver HAProvider to remove confusion.

Also this change is coherent with not accepting #904 

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
