### PR TITLE
refactor(knox): create symlink already in knox_gateway_config instead…

### DIFF
--- a/roles/knox/gateway/tasks/config.yml
+++ b/roles/knox/gateway/tasks/config.yml
@@ -251,3 +251,15 @@
     truststore_location: "/etc/pki/java/cacerts"
     truststore_password: "changeit"
     alias: "gateway-identity"
+
+# Replace the old configuration in the knox_install_dir with the new one
+- name: Backup {{ knox_install_dir }}/conf
+  ansible.builtin.command: mv {{ knox_install_dir }}/conf {{ knox_install_dir }}/conf.bk
+  args:
+    creates: "{{ knox_install_dir }}/conf.bk"
+
+- name: Create symbolic link from conf in {{ knox_install_dir }} to actual Knox config dir
+  ansible.builtin.file:
+    src: "{{ knox_conf_dir }}"
+    dest: "{{ knox_install_dir }}/conf"
+    state: link

--- a/roles/knox/ranger/tasks/config.yml
+++ b/roles/knox/ranger/tasks/config.yml
@@ -10,22 +10,6 @@
     group: root
     mode: "644"
 
-# Ranger installation scripts finds knox at "../knox" to add necessary properties to knox-site.xml, generate the ranger-*.xml
-# It can also be configured with COMPONENT_INSTALL_DIR_NAME but we still have to make {{ knox_install_dir }}/conf
-# a symbolic link to /etc/knox/conf.knox to get the configurations at the right place
-# TODO: find a better way to do this
-
-- name: Backup {{ knox_install_dir }}/conf
-  ansible.builtin.command: mv {{ knox_install_dir }}/conf {{ knox_install_dir }}/conf.bk
-  args:
-    creates: "{{ knox_install_dir }}/conf.bk"
-
-- name: Create symbolic link from conf in {{ knox_install_dir }} to actual Knox config dir
-  ansible.builtin.file:
-    src: "{{ knox_conf_dir }}"
-    dest: "{{ knox_install_dir }}/conf"
-    state: link
-
 # We also need to fix the path of the ranger-policymgr-ssl.xml containing the trustore properties in ranger-knox-security.xml
 - name: Fix the path of ranger-policymgr-ssl.xml in ranger-knox-security-changes.cfg
   ansible.builtin.lineinfile:


### PR DESCRIPTION
… of knox_ranger_config

<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

Symlink between `/etc/knox/conf` and `/opt/tdp/knox/conf` was not made in the gateway config yaml but in the config yaml of the ranger-knox-plugin which means that if variable changes are done but the playbook of the ranger-knox-plugin isn't used they will not be implemented.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
