### PR TITLE
fix(spark3): variabilize spark version for yarn shuffle

### DIFF
--- a/tdp_vars_defaults/spark3/spark3.yml
+++ b/tdp_vars_defaults/spark3/spark3.yml
@@ -4,7 +4,8 @@
 ---
 # Spark version
 spark_version: spark3
-spark_release: spark-3.2.4-1.0-bin-tdp
+spark_release_version: spark-3.2.4-1.0
+spark_release: "{{ spark_release_version }}-bin-tdp"
 spark_dist_file: "{{ spark_release }}.tgz"
 
 # Spark HBase Connector
@@ -18,7 +19,7 @@ hadoop_group: hadoop
 # Spark installation directory
 spark_root_dir: "{{ tdp_root_dir }}"
 spark_install_dir: "{{ spark_root_dir }}/spark3"
-spark_yarn_shuffle_path: "{{ spark_install_dir }}/yarn/spark-3.2.4-0.0-yarn-shuffle.jar"
+spark_yarn_shuffle_path: "{{ spark_install_dir }}/yarn/{{ spark_release_version }}-yarn-shuffle.jar"
 
 # Spark configuration directories
 spark_conf_dir: /etc/spark3


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes PR  [spark3: enable dynamic allocation #909](https://github.com/TOSIT-IO/tdp-collection/pull/909) 

#### Additional comments

Variabilize the spark-version in `spark_yarn_shuffle_path`.



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
