### PR TITLE
refactor(permissions): change all folder 777 permissions to 1777 in hdfs

### DIFF
--- a/roles/hive/common/tasks/hdfs_init.yml
+++ b/roles/hive/common/tasks/hdfs_init.yml
@@ -26,7 +26,7 @@
       state: directory
       owner: "{{ hive_user }}"
       group: "{{ hadoop_group }}"
-      mode: "777"
+      mode: "1777"
     - path: /tmp/hive
       state: directory
       owner: "{{ hive_user }}"

--- a/roles/spark/common/tasks/hdfs_init.yml
+++ b/roles/spark/common/tasks/hdfs_init.yml
@@ -21,7 +21,7 @@
       state: directory
       owner: "{{ spark_user }}"
       group: "{{ hadoop_group }}"
-      mode: "777"
+      mode: "1777"
     - path: "/user/spark"
       state: directory
       owner: "{{ spark_user }}"

--- a/roles/yarn/common/tasks/hdfs_init.yml
+++ b/roles/yarn/common/tasks/hdfs_init.yml
@@ -21,22 +21,22 @@
       state: directory
       owner: "{{ mapred_user }}"
       group: "{{ hadoop_group }}"
-      mode: "777"
+      mode: "1777"
     - path: /mr-history/done
       state: directory
       owner: "{{ mapred_user }}"
       group: "{{ hadoop_group }}"
-      mode: "777"
+      mode: "1777"
     - path: /mr-history/tmp
       state: directory
       owner: "{{ mapred_user }}"
       group: "{{ hadoop_group }}"
-      mode: "777"
+      mode: "1777"
     - path: /app-logs
       state: directory
       owner: "{{ yarn_user }}"
       group: "{{ hadoop_group }}"
-      mode: "777"
+      mode: "1777"
     - path: /ranger/audit/yarn
       state: directory
       owner: "{{ yarn_user }}"
@@ -44,7 +44,7 @@
       mode: "700"
     - path: /tmp
       state: directory
-      mode: "777"
+      mode: "1777"
     - path: /tmp/hadoop-yarn/staging
       state: directory
       owner: "{{ yarn_user }}"


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #931

#### Additional comments

Use sticky permissions `1777` instead of `777` for HDFS folders.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
