### PR TITLE
fix hbase_jmx-exporter: necessary fix to enable the phoenix-queryserver to start on TDP2

### DIFF
--- a/roles/hbase/common/tasks/jmx-exporter.yml
+++ b/roles/hbase/common/tasks/jmx-exporter.yml
@@ -8,5 +8,5 @@
     dest: "{{ hbase_root_conf_dir }}/{{ hbase_jmx_exporter_conf_file }}"
     owner: "{{ hbase_user }}"
     group: "{{ hadoop_group }}"
-    mode: "600"
+    mode: "640"
   no_log: true


### PR DESCRIPTION
#### Which issue(s) this PR fixes

Fixes #926 

#### Additional comments

The phoenix-queryserver does not start on TDP 2.0 due to a permission denied on the jmx_exporter.yml file for the version 6.0.0-2.0  of phoenix.

This modification fixes the issue since it enables phoenix to read the jmx_exporter.yml file.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
