### PR TITLE
YARN and JHS trough knox should support query parameters

### DIFF
--- a/roles/knox/common/templates/services/jobhistoryui/2.7.0/rewrite.xml
+++ b/roles/knox/common/templates/services/jobhistoryui/2.7.0/rewrite.xml
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<rules>
+  <rule dir="IN" name="JOBHISTORYUI/jobhistory/inbound/root" pattern="*://*:*/**/jobhistory/">
+    <rewrite template="{$serviceUrl[JOBHISTORYUI]}/jobhistory"/>
+  </rule>
+  <rule dir="IN" name="JOBHISTORYUI/jobhistory/inbound/path" pattern="*://*:*/**/jobhistory/{**}">
+    <rewrite template="{$serviceUrl[JOBHISTORYUI]}/jobhistory/{**}"/>
+  </rule>
+  <rule dir="IN" name="JOBHISTORYUI/jobhistory/inbound/query" pattern="*://*:*/**/jobhistory/{**}?{**}">
+    <rewrite template="{$serviceUrl[JOBHISTORYUI]}/jobhistory/{**}?{**}"/>
+  </rule>
+  <rule dir="IN" name="JOBHISTORYUI/jobhistory/inbound/static" pattern="*://*:*/**/jobhistory/static/{**}">
+    <rewrite template="{$serviceUrl[JOBHISTORYUI]}/static/{**}"/>
+  </rule>
+  <rule dir="IN" name="JOBHISTORYUI/jobhistory/inbound/jobhistory" pattern="*://*:*/**/jobhistory/jobhistory/{**}">
+    <rewrite template="{$serviceUrl[JOBHISTORYUI]}/jobhistory/{**}"/>
+  </rule>
+  <rule dir="IN" name="JOBHISTORYUI/jobhistory/inbound/jobhistory/params" pattern="*://*:*/**/jobhistory/jobhistory/{**}?{**}">
+    <rewrite template="{$serviceUrl[JOBHISTORYUI]}/jobhistory/{**}?{**}"/>
+  </rule>
+  <rule dir="IN" name="JOBHISTORYUI/jobhistory/inbound/conf" pattern="*://*:*/**/jobhistory/conf">
+    <rewrite template="{$serviceUrl[JOBHISTORYUI]}/conf"/>
+  </rule>
+  <rule dir="IN" name="JOBHISTORYUI/jobhistory/inbound/logs" pattern="*://*:*/**/jobhistory/logs">
+    <rewrite template="{$serviceUrl[JOBHISTORYUI]}/logs"/>
+  </rule>
+  <rule dir="IN" name="JOBHISTORYUI/jobhistory/inbound/joblogs" pattern="*://*:*/**/jobhistory/joblogs">
+    <rewrite template="{$serviceUrl[JOBHISTORYUI]}/jobhistory/logs"/>
+  </rule>
+  <rule dir="IN" name="JOBHISTORYUI/jobhistory/inbound/logs/files" pattern="*://*:*/**/jobhistory/logs/{**}">
+    <rewrite template="{$serviceUrl[JOBHISTORYUI]}/logs/{**}"/>
+  </rule>
+  <rule dir="IN" name="JOBHISTORYUI/jobhistory/inbound/joblogs/filecontent" pattern="*://*:*/**/jobhistory/joblogs/{**}">
+    <rewrite template="{$serviceUrl[JOBHISTORYUI]}/jobhistory/logs/{**}"/>
+  </rule>
+  <rule dir="IN" name="JOBHISTORYUI/jobhistory/inbound/joblogs/fullfilecontent" pattern="*://*:*/**/jobhistory/joblogs/{**}/?{**}">
+    <rewrite template="{$serviceUrl[JOBHISTORYUI]}/jobhistory/logs/{**}/?{**}"/>
+  </rule>
+  <rule dir="IN" name="JOBHISTORYUI/jobhistory/inbound/logs/redirect" pattern="*://*:*/**/jobhistory/logs?{scheme}?{host}?{port}?{**}">
+    <rewrite template="{scheme}://{host}:{port}/logs/?{**}"/>
+  </rule>
+  <rule dir="IN" name="JOBHISTORYUI/jobhistory/inbound/stacks" pattern="*://*:*/**/jobhistory/stacks">
+    <rewrite template="{$serviceUrl[JOBHISTORYUI]}/stacks"/>
+  </rule>
+  <rule dir="IN" name="JOBHISTORYUI/jobhistory/inbound/metrics" pattern="*://*:*/**/jobhistory/metrics">
+    <rewrite template="{$serviceUrl[JOBHISTORYUI]}/metrics"/>
+  </rule>
+  <rule dir="IN" name="JOBHISTORYUI/jobhistory/inbound/jmx" pattern="*://*:*/**/jobhistory/jmx">
+    <rewrite template="{$serviceUrl[JOBHISTORYUI]}/jmx"/>
+  </rule>
+  <rule dir="IN" name="JOBHISTORYUI/jobhistory/inbound/jmx/query" pattern="*://*:*/**/jobhistory/jmx?{**}">
+    <rewrite template="{$serviceUrl[JOBHISTORYUI]}/jmx?{**}"/>
+  </rule>
+  <rule dir="IN" name="JOBHISTORYUI/jobhistory/inbound/logs" pattern="*://*:*/**/jobhistory/logs?{scheme}?{host}?{port}?{**}">
+    <rewrite template="{scheme}://{host}:{port}/logs/?{**}"/>
+  </rule>
+
+  <!-- job history ws rest api -->
+  <rule dir="IN" name="JOBHISTORYUI/jobhistory/inbound/ws" pattern="*://*:*/**/jobhistory/ws/{**}?{**}">
+    <rewrite template="{$serviceUrl[JOBHISTORYUI]}/ws/{**}?{**}"/>
+  </rule>
+
+  <rule dir="IN" name="JOBHISTORYUI/nodelink/inbound" pattern="*://*:*/**/jobhistory/node?{scheme}?{host}?{port}">
+    <rewrite template="{scheme}://{host}:{port}/node?{scheme}?{host}?{port}"/>
+  </rule>
+
+  <rule dir="IN" name="JOBHISTORYUI/jobhistory/inbound/node" pattern="*://*:*/**/jobhistory/node?{host}&amp;{port=**}">
+    <rewrite template="http://{host}:{port=**}/node"/>
+  </rule>
+
+  <!-- request out web content rewrite rules -->
+
+  <!-- rewrite map reduce node manager request -->
+  <!-- This maps to Nodemanager           -->
+  <rule dir="OUT" name="JOBHISTORYUI/nodelink" pattern="{scheme}://{host}:{port}">
+    <rewrite template="{$frontend[scheme]}://{$frontend[address]}/gateway/nodemanagerui/node?{host}"/>
+  </rule>
+
+  <!-- static web resources (css, js, jpeg, etc). -->
+  <rule dir="OUT" name="JOBHISTORYUI/jobhistory/outbound/static" pattern="/static/{**}">
+    <rewrite template="{$frontend[url]}/jobhistory/static/{**}"/>
+  </rule>
+  <rule dir="OUT" name="JOBHISTORYUI/jobhistory/outbound/jobhistory" pattern="/jobhistory/{**}">
+    <rewrite template="{$frontend[url]}/jobhistory/{**}"/>
+  </rule>
+  <rule dir="OUT" name="JOBHISTORYUI/jobhistory/outbound/jobhistory/query" pattern="/jobhistory/{**}?{**}">
+    <rewrite template="{$frontend[url]}/jobhistory/{**}?{**}"/>
+  </rule>
+
+  <!-- tab content rewrite e.g. /conf, /logs, /stacks, /metrics,/jmx, etc -->
+  <rule dir="OUT" name="JOBHISTORYUI/jobhistory/outbound/logs/files" pattern="/logs/{**}">
+    <rewrite template="{$frontend[url]}/jobhistory/logs/{**}"/>
+  </rule>
+  <rule dir="OUT" name="JOBHISTORYUI/jobhistory/outbound/jobhistory/logs" pattern="/jobhistory/logs/{**}/?{**}">
+    <rewrite template="{$frontend[url]}/jobhistory/joblogs/{**}/?{**}"/>
+  </rule>
+  <rule dir="OUT" name="JOBHISTORYUI/jobhistory/outbound/conf" pattern="/conf">
+    <rewrite template="{$frontend[url]}/jobhistory/conf"/>
+  </rule>
+  <rule dir="OUT" name="JOBHISTORYUI/jobhistory/outbound/logs" pattern="/logs">
+    <rewrite template="{$frontend[url]}/jobhistory/logs"/>
+  </rule>
+  <rule dir="OUT" name="JOBHISTORYUI/jobhistory/outbound/stacks" pattern="/stacks">
+    <rewrite template="{$frontend[url]}/jobhistory/stacks"/>
+  </rule>
+  <rule dir="OUT" name="JOBHISTORYUI/jobhistory/outbound/metrics" pattern="/metrics">
+    <rewrite template="{$frontend[url]}/jobhistory/metrics"/>
+  </rule>
+  <rule dir="OUT" name="JOBHISTORYUI/jobhistory/outbound/jmx" pattern="/jmx?{**}">
+    <rewrite template="{$frontend[url]}/jobhistory/jmx?{**}"/>
+  </rule>
+
+
+  <!-- 302 redirection for jobs, tasks, logs -->
+  <filter name="JOBHISTORYUI/jobhistory/outbound/headers">
+    <content type="application/x-http-headers">
+      <apply path="Location" rule="JOBHISTORYUI/jobhistory/outbound/headers/location"/>
+    </content>
+  </filter>
+  <rule dir="OUT" name="JOBHISTORYUI/jobhistory/outbound/headers/location">
+    <match pattern="{scheme}://{host}:{port}/logs/?{**}"/>
+    <rewrite template="{$frontend[url]}/jobhistory/logs?{scheme}?host={$hostmap(host)}?{port}?{**}"/>
+  </rule>
+
+  <!-- xml content rewrite  -->
+  <filter name="JOBHISTORYUI/jobhistory/outbound/configuration">
+    <content type="*/xml">
+      <buffer path="/configuration/property"/>
+    </content>
+  </filter>
+
+  <!-- embedded javascript content rewrite -->
+  <filter name="JOBHISTORYUI/jobhistory/outbound/jobs">
+    <content type="*/html">
+      <apply path="https?://[^/':,]+:[\d]+" rule="JOBHISTORYUI/jobhistory/outbound/jobs/node"/>
+      <apply path="/jobhistory/job" rule="JOBHISTORYUI/jobhistory/outbound/jobs/job"/>
+      <apply path="/jobhistory/task" rule="JOBHISTORYUI/jobhistory/outbound/jobs/task"/>
+      <apply path="/jobhistory/logs" rule="JOBHISTORYUI/jobhistory/outbound/jobs/logs"/>
+    </content>
+  </filter>
+
+  <!-- rules for embedded js rewrite   -->
+  <rule dir="OUT" name="JOBHISTORYUI/jobhistory/outbound/jobs/job">
+    <rewrite template="{$frontend[url]}/jobhistory/job"/>
+  </rule>
+  <rule dir="OUT" name="JOBHISTORYUI/jobhistory/outbound/jobs/task">
+    <rewrite template="{$frontend[url]}/jobhistory/task"/>
+  </rule>
+  <rule dir="OUT" name="JOBHISTORYUI/jobhistory/outbound/jobs/logs">
+    <rewrite template="{$frontend[url]}/jobhistory/joblogs"/>
+  </rule>
+
+  <rule dir="OUT" name="JOBHISTORYUI/jobhistory/outbound/jobs/node">
+    <match pattern="{scheme}://{host}:{port}"/>
+    <rewrite template="{$frontend[url]}/jobhistory/node?{host}?{port}"/>
+  </rule>
+</rules>

--- a/roles/knox/common/templates/services/yarnui/2.7.0/rewrite.xml.j2
+++ b/roles/knox/common/templates/services/yarnui/2.7.0/rewrite.xml.j2
@@ -23,8 +23,8 @@
      e.g. http://host.com:8088
 -->
 
-<rule dir="IN" name="YARNUI/yarn/inbound/ws" pattern="*://*:*/**/yarn/ws/v1/{**}">
-    <rewrite template="{$serviceUrl[YARNUI]}/ws/v1/{**}"/>
+<rule dir="IN" name="YARNUI/yarn/inbound/ws" pattern="*://*:*/**/yarn/ws/v1/{**}?{**}">
+    <rewrite template="{$serviceUrl[YARNUI]}/ws/v1/{**}?{**}"/>
 </rule>
 <rule dir="IN" name="YARNUI/yarn/inbound/root" pattern="*://*:*/**/yarn/">
     <rewrite template="{$serviceUrl[YARNUI]}/cluster"/>

--- a/roles/knox/gateway/tasks/config.yml
+++ b/roles/knox/gateway/tasks/config.yml
@@ -138,6 +138,14 @@
     group: "{{ knox_group }}"
     mode: "644"
 
+- name: Template Job History UI rewrite.xml
+  ansible.builtin.template:
+    src: services/jobhistoryui/2.7.0/rewrite.xml.j2
+    dest: "{{ knox_data_dir }}/data/services/jobhistoryui/2.7.0/rewrite.xml"
+    owner: "{{ knox_user }}"
+    group: "{{ knox_group }}"
+    mode: "644"
+
 - name: Template Knox gateway-site.xml
   ansible.builtin.template:
     src: gateway-site.xml.j2


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #936 

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

For YARN, this is a backport from default knox topology found here https://github.com/apache/knox/pull/921

For JHS, the only difference from knox upstream is:

```diff
-  <!-- job history ws rest api -->
-  <rule dir="IN" name="JOBHISTORYUI/jobhistory/inbound/ws" pattern="*://*:*/**/jobhistory/ws/{**}">
-    <rewrite template="{$serviceUrl[JOBHISTORYUI]}/ws/{**}"/>
-  </rule>
+  <!-- job history ws rest api -->
+  <rule dir="IN" name="JOBHISTORYUI/jobhistory/inbound/ws" pattern="*://*:*/**/jobhistory/ws/{**}?{**}">
+    <rewrite template="{$serviceUrl[JOBHISTORYUI]}/ws/{**}?{**}"/>
+  </rule>
```

This PR needs a bit of testing, currently in draft

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
