### PR TITLE
fix(spark): use log4j2 log configuration

### DIFF
--- a/roles/spark/common/templates/log4j2.properties.j2
+++ b/roles/spark/common/templates/log4j2.properties.j2
@@ -1,0 +1,98 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Set everything to be logged to the console
+rootLogger.level = {{ spark_root_logger_level }}
+rootLogger.appenderRef.stdout.ref = {{ spark_root_logger }}
+
+# In the pattern layout configuration below, we specify an explicit `%ex` conversion
+# pattern for logging Throwables. If this was omitted, then (by default) Log4J would
+# implicitly add an `%xEx` conversion pattern which logs stacktraces with additional
+# class packaging information. That extra information can sometimes add a substantial
+# performance overhead, so we disable it in our default logging config.
+# For more information, see SPARK-39361.
+appender.console.type = Console
+appender.console.name = console
+appender.console.target = SYSTEM_ERR
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n%ex
+
+#
+# Daily Rolling File Appender
+#
+appender.DRFA.type = RollingFile
+appender.DRFA.name = DRFA
+appender.DRFA.fileName = {{ spark_log_dir }}/{{ spark_hs_log_file }}
+appender.DRFA.filePattern = {{ spark_log_dir }}/{{ spark_hs_log_file }}.{{ spark_log_drfa_date_pattern }}
+appender.DRFA.layout.type = PatternLayout
+appender.DRFA.layout.pattern = {{ spark_log_layout_pattern }}
+appender.DRFA.policies.type = Policies
+appender.DRFA.policies.timebased.type = TimeBasedTriggeringPolicy
+appender.DRFA.policies.timebased.interval = 1
+appender.DRFA.policies.timebased.modulate = false
+appender.DRFA.strategy.type = DefaultRolloverStrategy
+appender.DRFA.strategy.max = 30
+
+# Rolling File Appender
+appender.RFA.type = RollingFile
+appender.RFA.name = RFA
+appender.RFA.fileName = {{ spark_log_dir }}/{{ spark_hs_log_file }}
+appender.RFA.filePattern = {{ spark_log_dir }}/{{ spark_hs_log_file }}.%i
+appender.RFA.layout.type = PatternLayout
+appender.RFA.layout.pattern = {{ spark_log_layout_pattern }}
+appender.RFA.policies.type = Policies
+appender.RFA.policies.sizebased.type = SizeBasedTriggeringPolicy
+appender.RFA.policies.sizebased.size = {{ spark_log_rfa_maxfilesize }}
+appender.RFA.strategy.type = DefaultRolloverStrategy
+appender.RFA.strategy.max = {{ spark_log_rfa_maxbackupindex }}
+
+# Set the default spark-shell/spark-sql log level to WARN. When running the
+# spark-shell/spark-sql, the log level for these classes is used to overwrite
+# the root logger's log level, so that the user can have different defaults
+# for the shell and regular Spark apps.
+logger.repl.name = org.apache.spark.repl.Main
+logger.repl.level = warn
+
+logger.thriftserver.name = org.apache.spark.sql.hive.thriftserver.SparkSQLCLIDriver
+logger.thriftserver.level = warn
+
+# Settings to quiet third party logs that are too verbose
+logger.jetty1.name = org.sparkproject.jetty
+logger.jetty1.level = warn
+logger.jetty2.name = org.sparkproject.jetty.util.component.AbstractLifeCycle
+logger.jetty2.level = error
+logger.replexprTyper.name = org.apache.spark.repl.SparkIMain$exprTyper
+logger.replexprTyper.level = info
+logger.replSparkILoopInterpreter.name = org.apache.spark.repl.SparkILoop$SparkILoopInterpreter
+logger.replSparkILoopInterpreter.level = info
+logger.parquet1.name = org.apache.parquet
+logger.parquet1.level = error
+logger.parquet2.name = parquet
+logger.parquet2.level = error
+
+# SPARK-9183: Settings to avoid annoying messages when looking up nonexistent UDFs in SparkSQL with Hive support
+logger.RetryingHMSHandler.name = org.apache.hadoop.hive.metastore.RetryingHMSHandler
+logger.RetryingHMSHandler.level = fatal
+logger.FunctionRegistry.name = org.apache.hadoop.hive.ql.exec.FunctionRegistry
+logger.FunctionRegistry.level = error
+
+# For deploying Spark ThriftServer
+# SPARK-34128: Suppress undesirable TTransportException warnings involved in THRIFT-4805
+appender.console.filter.1.type = RegexFilter
+appender.console.filter.1.regex = .*Thrift error occurred during processing of message.*
+appender.console.filter.1.onMatch = deny
+appender.console.filter.1.onMismatch = neutral

--- a/roles/spark/historyserver/tasks/config.yml
+++ b/roles/spark/historyserver/tasks/config.yml
@@ -32,10 +32,20 @@
   vars:
     spark_defaults: "{{ spark_defaults_common | combine(spark_defaults_hs) }}"
 
-- name: Template {{ spark_version | capitalize }} History Server log4j file
+- name: Template Spark History Server log4j file
   ansible.builtin.template:
     src: log4j.properties.j2
     dest: "{{ spark_hs_conf_dir }}/log4j.properties"
     owner: root
     group: root
     mode: "644"
+  when: spark_version == "spark"
+
+- name: Template Spark3 History Server log4j file
+  ansible.builtin.template:
+    src: log4j2.properties.j2
+    dest: "{{ spark_hs_conf_dir }}/log4j2.properties"
+    owner: root
+    group: root
+    mode: "644"
+  when: spark_version == "spark3"

--- a/tdp_vars_defaults/spark3/spark3.yml
+++ b/tdp_vars_defaults/spark3/spark3.yml
@@ -42,7 +42,7 @@ spark_log_dir: "{{ spark3_log_dir }}"
 spark_hs_log_file: "{{ spark3_hs_log_file }}"
 spark_log_layout_pattern: "{{ tdp_log_layout_pattern }}"
 # DRFA appenders config
-spark_log_drfa_date_pattern: "'.'yyyy-MM-dd-HH-mm"
+spark_log_drfa_date_pattern: "%d{yyyy-MM-dd-HH-mm}"
 # RFA appenders config
 spark_log_rfa_maxfilesize: 256MB
 spark_log_rfa_maxbackupindex: 10


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #927

#### Additional comments

Use log4j2 configuration. RFA and DRFA do not rollover but the same with configuration in spark2 which uses log4j1.



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
