### PR TITLE
fix: name of the metastore uris parameter

### DIFF
--- a/tdp_vars_defaults/hive/hive.yml
+++ b/tdp_vars_defaults/hive/hive.yml
@@ -82,7 +82,6 @@ hive_site:
   # Metastore server and client properties
   hive.metastore.sasl.enabled: "true"
   metastore.kerberos.principal: hive/_HOST@{{ realm }}
-  metastore.thrift.uri.selection: RANDOM
   hive.metastore.uris: >-
     {{
       groups['hive_ms'] |


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #926 

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->
Intermittent errors occurred during partition loading in Hive tables, with the following message:

```INFO  : Loading data to table tdp_user_integration_tests.tbl_wine_by_qual_textfile_dyn partition (quality=null) from hdfs://mycluster/user/tdp_user/warehouse/tdp_user_integration_tests/tbl_wine_by_qual_textfile_dyn/.hive-staging_hive_2025-05-02_10-22-51_736_6398194159283575754-1/-ext-10000
INFO  : 

ERROR : FAILED: Execution Error, return code 40000 from org.apache.hadoop.hive.ql.exec.MoveTask. Exception when loading 6 partitions in table tbl_wine_by_qual_textfile_dyn with loadPath=hdfs://mycluster/user/tdp_user/warehouse/tdp_user_integration_tests/tbl_wine_by_qual_textfile_dyn/.hive-staging_hive_2025-05-02_10-22-51_736_6398194159283575754-1/-ext-10000
INFO  : Completed executing command(queryId=hive_20250502102251_7d945ba7-9c12-4260-840e-75f4184428a3); Time taken: 60.982 seconds
Error: Error while compiling statement: FAILED: Execution Error, return code 40000 from org.apache.hadoop.hive.ql.exec.MoveTask. Exception when loading 6 partitions in table tbl_wine_by_qual_textfile_dyn with loadPath=hdfs://mycluster/user/tdp_user/warehouse/tdp_user_integration_tests/tbl_wine_by_qual_textfile_dyn/.hive-staging_hive_2025-05-02_10-22-51_736_6398194159283575754-1/-ext-10000 (state=08S01,code=40000)
```

Investigation revealed that the Metastore connection parameter was misnamed as `metastore.thrift.uris` instead of the correct `hive.metastore.uris`. This incorrect parameter name caused Hive to fail to reliably connect to the Metastore, resulting in random failures during operations.

This change ensures a proper and stable connection to the Metastore, eliminating intermittent errors during partition loading.

[Hive 3 documentation](https://hive.apache.org/docs/latest/adminmanual-metastore-3-0-administration_75978150/)
[Hive 4 documentation](https://hive.apache.org/docs/latest/adminmanual-metastore-administration_27362076/)

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
