### PR TITLE
refactor: add follow=false for recurse option in ansible

### DIFF
--- a/roles/hbase/common/tasks/install_hbase.yml
+++ b/roles/hbase/common/tasks/install_hbase.yml
@@ -44,6 +44,7 @@
     mode: "755"
     state: directory
     recurse: true
+    follow: false
 
 - name: Create symbolic link to HBase installation
   ansible.builtin.file:

--- a/roles/hbase/common/tasks/install_phoenix.yml
+++ b/roles/hbase/common/tasks/install_phoenix.yml
@@ -29,6 +29,7 @@
     mode: "755"
     state: directory
     recurse: true
+    follow: false
 
 - name: Create symbolic link to Phoenix installation
   ansible.builtin.file:

--- a/roles/hbase/phoenix/queryserver/common/tasks/install.yml
+++ b/roles/hbase/phoenix/queryserver/common/tasks/install.yml
@@ -36,6 +36,7 @@
     mode: "755"
     state: directory
     recurse: true
+    follow: false
 
 - name: Create symbolic link to Phoenix QueryServer installation
   ansible.builtin.file:

--- a/roles/hbase/ranger/tasks/install.yml
+++ b/roles/hbase/ranger/tasks/install.yml
@@ -28,6 +28,7 @@
     group: root
     mode: "755"
     recurse: true
+    follow: false
     state: directory
 
 - name: Create symbolic link to Ranger installation

--- a/roles/hdfs/namenode/tasks/start_standby_nn.yml
+++ b/roles/hdfs/namenode/tasks/start_standby_nn.yml
@@ -15,6 +15,7 @@
     owner: "{{ hdfs_user }}"
     group: "{{ hadoop_group }}"
     recurse: true
+    follow: false
 
 - name: Start standby namenode
   ansible.builtin.service:

--- a/roles/hdfs/ranger/tasks/install.yml
+++ b/roles/hdfs/ranger/tasks/install.yml
@@ -28,6 +28,7 @@
     group: root
     mode: "755"
     recurse: true
+    follow: false
     state: directory
 
 - name: Create symbolic link to Ranger installation

--- a/roles/hive/common/tasks/install_hive.yml
+++ b/roles/hive/common/tasks/install_hive.yml
@@ -29,6 +29,7 @@
     mode: "755"
     state: directory
     recurse: true
+    follow: false
 
 - name: Create symbolic link to Hive installation
   ansible.builtin.file:

--- a/roles/hive/ranger/tasks/install.yml
+++ b/roles/hive/ranger/tasks/install.yml
@@ -28,6 +28,7 @@
     group: root
     mode: "755"
     recurse: true
+    follow: false
     state: directory
 
 - name: Create symbolic link to Ranger installation

--- a/roles/knox/common/tasks/install.yml
+++ b/roles/knox/common/tasks/install.yml
@@ -58,6 +58,7 @@
     group: root
     mode: "755"
     recurse: true
+    follow: false
   loop:
     - "{{ knox_root_dir }}/{{ knox_release }}"
     - "{{ knox_root_dir }}/{{ knoxshell_release }}"

--- a/roles/knox/ranger/tasks/install.yml
+++ b/roles/knox/ranger/tasks/install.yml
@@ -28,6 +28,7 @@
     group: root
     mode: "755"
     recurse: true
+    follow: false
     state: directory
 
 - name: Create symbolic link to Ranger installation

--- a/roles/ranger/admin/tasks/config.yml
+++ b/roles/ranger/admin/tasks/config.yml
@@ -28,6 +28,7 @@
     mode: "755"
     state: directory
     recurse: true
+    follow: false
 
 - name: Ensure right permissions on {{ ranger_install_dir }}/conf/.jceks folder
   ansible.builtin.file:

--- a/roles/yarn/nodemanager/tasks/install.yml
+++ b/roles/yarn/nodemanager/tasks/install.yml
@@ -79,5 +79,6 @@
     group: "{{ item.group }}"
     mode: "{{ item.mode }}"
     recurse: true
+    follow: false
   loop: "{{ cgroups_yarn_dirs }}"
   when: cgroups_enabled

--- a/roles/yarn/ranger/tasks/install.yml
+++ b/roles/yarn/ranger/tasks/install.yml
@@ -28,6 +28,7 @@
     group: root
     mode: "755"
     recurse: true
+    follow: false
     state: directory
 
 - name: Create symbolic link to Ranger installation


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

 As stated in #940 with [`follow: false`](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/file_module.html#parameter-follow) files related to symlinks do not change permissions. By default, for ansible < 2.5 it is false (we currently use version 2.15), but for versions superior to 2.5 it is set by default to true.



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
