### PR TITLE
fix(knox): correct log4j2 config

### DIFF
--- a/roles/knox/common/templates/gateway-log4j2.xml.j2
+++ b/roles/knox/common/templates/gateway-log4j2.xml.j2
@@ -13,21 +13,24 @@
         <Console name="stdout" target="SYSTEM_OUT">
             <PatternLayout pattern="{{ knox_log_layout_pattern }}" />
         </Console>
+        {% if knox_root_logger=="DRFA" %}
         <RollingFile name="DRFA" fileName="${app.log.dir}/${app.log.file}" filePattern="${app.log.dir}/${app.log.file}.{{ knox_log_drfa_date_pattern }}">
             <PatternLayout pattern="{{ knox_log_layout_pattern }}" />
             <TimeBasedTriggeringPolicy />
         </RollingFile>
+        {% else %}
         <RollingFile name="RFA" fileName="${app.log.dir}/${app.log.file}" filePattern="${app.log.dir}/${app.log.file}.%i">
             <PatternLayout pattern="{{ knox_log_layout_pattern }}" />
             <SizeBasedtriggeringPolicy size="{{ knox_log_rfa_maxfilesize }}"/>
             <DefaultRolloverStrategy max="{{ knox_log_rfa_maxhistory }}"/>
         </RollingFile>
+        {% endif %}
         <RollingFile name="KNOXAGENT" fileName="${app.log.dir}/ranger.knoxagent.log" filePattern="${app.log.dir}/ranger.knoxagent.log.{{ knox_log_drfa_date_pattern }}">
             <PatternLayout pattern="{{ knox_log_layout_pattern }}"/>
             <TimeBasedTriggeringPolicy />
         </RollingFile>
         {% if enable_ranger_audit_log4j %}
-        <RollingFile name="ranger_audit" fileName="${app.log.dir}/${app.log.file}" filePattern="${app.log.dir}//{{ knox_ranger_audit_file }}.{{ knox_log_drfa_date_pattern }}">
+        <RollingFile name="ranger_audit" fileName="${app.log.dir}/{{ knox_ranger_audit_file }}" filePattern="${app.log.dir}/{{ knox_ranger_audit_file }}.{{ knox_log_drfa_date_pattern }}">
             <PatternLayout pattern="{{ tdp_auditlog_layout_pattern }}" />
             <TimeBasedTriggeringPolicy />
         </RollingFile>
@@ -57,7 +60,7 @@
             <AppenderRef ref="{{ knox_root_logger }}" />
         </Root>
         {% if enable_ranger_audit_log4j %}
-        <Logger name="ranger_audit" level="INFO">
+        <Logger name="xaaudit" level="INFO">
             <AppenderRef ref="ranger_audit" />
         </Logger>
         {% endif %}

--- a/roles/knox/common/templates/knoxcli-log4j2.xml.j2
+++ b/roles/knox/common/templates/knoxcli-log4j2.xml.j2
@@ -24,15 +24,18 @@ This XML file does not appear to have any style information associated with it. 
         <Console name="stdout" target="SYSTEM_OUT">
             <PatternLayout pattern="{{ knox_log_layout_pattern }}"/>
         </Console>
+        {% if knox_root_logger=="DRFA" %}
         <RollingFile name="DRFA" fileName="${app.log.dir}/${app.log.file}" filePattern="${app.log.dir}/${app.log.file}.{{ knox_log_drfa_date_pattern }}">
             <PatternLayout pattern="{{ knox_log_layout_pattern }}"/>
             <TimeBasedTriggeringPolicy/>
         </RollingFile>
+        {% else %}
         <RollingFile name="RFA" fileName="${app.log.dir}/${app.log.file}" filePattern="${app.log.dir}/${app.log.file}.%i">
             <PatternLayout pattern="{{ knox_log_layout_pattern }}" />
             <SizeBasedtriggeringPolicy size="{{ knox_log_rfa_maxfilesize }}"/>
             <DefaultRolloverStrategy max="{{ knox_log_rfa_maxhistory }}"/>
         </RollingFile>
+        {% endif %}
     </Appenders>
     <Loggers>
         <Logger name="org.apache.knox.gateway" level="INFO"/>

--- a/roles/knox/common/templates/ldap-log4j2.xml.j2
+++ b/roles/knox/common/templates/ldap-log4j2.xml.j2
@@ -23,15 +23,18 @@
         <Console name="stdout" target="SYSTEM_OUT">
             <PatternLayout pattern="{{ knox_log_layout_pattern }}"/>
         </Console>
+        {% if knox_root_logger=="DRFA" %}
         <RollingFile name="DRFA" fileName="${app.log.dir}/${app.log.file}" filePattern="${app.log.dir}/${app.log.file}.{{ knox_log_drfa_date_pattern }}">
             <PatternLayout pattern="{{ knox_log_layout_pattern }}"/>
             <TimeBasedTriggeringPolicy/>
         </RollingFile>
-        <<RollingFile name="RFA" fileName="${app.log.dir}/${app.log.file}" filePattern="${app.log.dir}/${app.log.file}.%i">
+        {% else %}
+        <RollingFile name="RFA" fileName="${app.log.dir}/${app.log.file}" filePattern="${app.log.dir}/${app.log.file}.%i">
             <PatternLayout pattern="{{ knox_log_layout_pattern }}" />
             <SizeBasedtriggeringPolicy size="{{ knox_log_rfa_maxfilesize }}"/>
             <DefaultRolloverStrategy max="{{ knox_log_rfa_maxhistory }}"/>
         </RollingFile>
+        {% endif %}
     </Appenders>
     <Loggers>
         <Logger name="org.apache.directory" level="WARN"/>

--- a/roles/knox/common/templates/shell-log4j2.xml.j2
+++ b/roles/knox/common/templates/shell-log4j2.xml.j2
@@ -23,15 +23,18 @@
         <Console name="stdout" target="SYSTEM_OUT">
             <PatternLayout pattern="{{ knox_log_layout_pattern }}"/>
         </Console>
+        {% if knox_root_logger=="DRFA" %}
         <RollingFile name="DRFA" fileName="${app.log.dir}/${app.log.file}" filePattern="${app.log.dir}/${app.log.file}.{{ knox_log_drfa_date_pattern }}">
             <PatternLayout pattern="{{ knox_log_layout_pattern }}"/>
             <TimeBasedTriggeringPolicy/>
         </RollingFile>
+        {% else %}
         <RollingFile name="RFA" fileName="${app.log.dir}/${app.log.file}" filePattern="${app.log.dir}/${app.log.file}.%i">
             <PatternLayout pattern="{{ knox_log_layout_pattern }}" />
             <SizeBasedtriggeringPolicy size="{{ knox_log_rfa_maxfilesize }}"/>
             <DefaultRolloverStrategy max="{{ knox_log_rfa_maxhistory }}"/>
         </RollingFile>
+        {% endif %}
     </Appenders>
     <Loggers>
         <Root level="ERROR">


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #944

#### Additional comments

- We have realized that in a xml file if two appenders had the same `fileName`, the logger would take properties of both appendres although they have different names. So now the log4j2.xml files only contain either RFA by default or DRFA but not both.
- `ranger_audit_log4j` has been corrected.
- As well as a typo.



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
