### PR TITLE
feat(zookeeper): allow specific 4lw commands via whitelist

### DIFF
--- a/tdp_vars_defaults/zookeeper/zookeeper.yml
+++ b/tdp_vars_defaults/zookeeper/zookeeper.yml
@@ -87,6 +87,7 @@ zookeeper_cfg:
   kerberos.removeRealmFromPrincipal: "true"
   # Zookeeper AdminServer
   admin.serverPort: '{{ zookeeper_admin_server_port }}'
+  4lw.commands.whitelist: ruok, mntr, conf
 
 # Service start on boot policies
 zk_start_on_boot: false


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #926 

#### Additional comments


Adds the following line to the default ZooKeeper configuration:
```
4lw.commands.whitelist: ruok, mntr, conf
```
By default, no "four-letter word" commands are allowed, preventing basic health checks and monitoring. This change enables:

- **ruok**: Quick server health check.
- **mntr**: Detailed server metrics.
- **conf**: Retrieve current server configuration.


#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
