### PR TITLE
refactor(hive): moves db configs to hive-site

### DIFF
--- a/tdp_vars_defaults/hive/hive.yml
+++ b/tdp_vars_defaults/hive/hive.yml
@@ -90,26 +90,26 @@ hive_site:
       list |
       join(',')
     }}
-  # Disable for Iceberg, possible to enable at runtime 
+  hive.metastore.db.type: POSTGRES
+  metastore.warehouse.dir: /warehouse/tablespace/managed/hive
+  metastore.warehouse.external.dir: /warehouse/tablespace/external/hive
+  javax.jdo.option.ConnectionURL: "{{ hive_ms_db_url }}/{{ hive_ms_db_name }}"
+  javax.jdo.option.ConnectionDriverName: org.postgresql.Driver
+  javax.jdo.option.ConnectionPassword: "{{ hive_ms_db_password }}"
+  javax.jdo.option.ConnectionUserName: "{{ hive_ms_db_user }}"
+  # Disable for Iceberg, possible to enable at runtime
   hive.vectorized.execution.enabled: "false"
 
 metastore_site:
   datanucleus.schema.autoCreateAll: "false"
-  javax.jdo.option.ConnectionURL: "{{ hive_ms_db_url }}/{{ hive_ms_db_name }}"
-  javax.jdo.option.ConnectionDriverName: org.postgresql.Driver
-  javax.jdo.option.ConnectionUserName: "{{ hive_ms_db_user }}"
+
   metastore.hmshandler.retry.interval: 2
   metastore.hmshandler.retry.attempts: 10
   metastore.stats.autogather: "true"
   metastore.metrics.enabled: "true"
-  # defined in hive_site
-  # metastore.sasl.enabled: "true"
-  # metastore.kerberos.principal: hive/_HOST@{{ realm }}
   metastore.kerberos.keytab.file: /etc/security/keytabs/hive.service.keytab
   metastore.schema.verification: "true"
   metastore.schema.verification.record.version: "true"
-  metastore.warehouse.dir: /warehouse/tablespace/managed/hive
-  metastore.warehouse.external.dir: /warehouse/tablespace/external/hive
   metastore.cluster.delegation.token.store.class: org.apache.hadoop.hive.thrift.DBTokenStore
 
 hiveserver2_site:
@@ -187,7 +187,7 @@ tez_site:
   # Tez allocated vcores per container for Hive
   hive.tez.cpu.vcores: 1
   # Necessary for Projection Pruning with Iceberg
-  tez.mrreader.config.update.properties: hive.io.file.readcolumn.names,hive.io.file.readcolumn.ids 
+  tez.mrreader.config.update.properties: hive.io.file.readcolumn.names,hive.io.file.readcolumn.ids
 
 # Service start on boot policies
 hiveserver2_start_on_boot: no


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #985 

#### Additional comments

Hive is not registering properties like db.type and metastore.warehouse when they are defined in metastore-site. This pr  moves the properties to the hivesite config.
Some other config/security changes may need to be made depending on how the default hive.server2.enable.doAs is to be set because hive 4+ expects managed tables to be owned by hive.



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
