### PR TITLE
refactor: share access_fqdn function

### DIFF
--- a/plugins/filter/access_fqdn.py
+++ b/plugins/filter/access_fqdn.py
@@ -2,18 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from ansible.errors import AnsibleError
+from ansible_collections.tosit.tdp.plugins.module_utils.access_fqdn import access_fqdn
+
 
 class FilterModule(object):
     def filters(self):
         return {'access_fqdn': self.access_fqdn}
 
     def access_fqdn(self, host, hostvars):
-        if 'access_fqdn' in hostvars[host]:
-            return hostvars[host]['access_fqdn']
-        elif 'domain' in hostvars[host]:
-            if 'access_sn' in hostvars[host]:
-                return hostvars[host]['access_sn'] + '.' + hostvars[host]['domain']
-            else:
-                return hostvars[host]['inventory_hostname'] + '.' + hostvars[host]['domain']
-        else:
-            raise AnsibleError("Required variables: `access_fqdn` or `domain`")
+        return access_fqdn(host, hostvars)

--- a/plugins/module_utils/access_fqdn.py
+++ b/plugins/module_utils/access_fqdn.py
@@ -1,0 +1,15 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+from ansible.errors import AnsibleError
+
+def access_fqdn(host, hostvars):
+    if 'access_fqdn' in hostvars[host]:
+        return hostvars[host]['access_fqdn']
+    elif 'domain' in hostvars[host]:
+        if 'access_sn' in hostvars[host]:
+            return hostvars[host]['access_sn'] + '.' + hostvars[host]['domain']
+        else:
+            return hostvars[host]['inventory_hostname'] + '.' + hostvars[host]['domain']
+    else:
+        raise AnsibleError("Required variables: `access_fqdn` or `domain`")


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #

#### Additional comments

Make the access_fqdn function sharable with other modules.
This is needed for refactoring some observability roles which will use a `lookup` plugin instead of nested loops in ansible.
This lookup plugin will need to compute fqdn of ansible hosts



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
