### PR TITLE
refactor(spark): use catalog iceberg for iceberg operations and leave…

### DIFF
--- a/tdp_vars_defaults/spark3/spark3.yml
+++ b/tdp_vars_defaults/spark3/spark3.yml
@@ -175,6 +175,9 @@ spark_defaults_iceberg:
   # Spark catalog 'iceberg' configured only for Iceberg operations
   spark.sql.catalog.iceberg: org.apache.iceberg.spark.SparkCatalog
   spark.sql.catalog.iceberg.type: hive
+  # The properties below replicate the properties when creating an Iceberg table with `CREATE TABLE` in Beeline
+  # spark.sql.catalog.iceberg.table-override.external.table.purge: true
+  # spark.sql.catalog.iceberg.table-override.iceberg.orc.files.only: false
 
 # spark-env.sh - common
 spark_env_common:


### PR DESCRIPTION
… spark default catalog empty

<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #978

#### Additional comments

In addition to fix the mentioned issue with the first commit, the second commit adds fixed non overridable table properties `external.table.purge` set to `true` and `iceberg.orc.files.only` set to `false` to mimic the iceberg table properties set by default with beeline.

However, the behaviour is not the same when the same task is executed in spark or hive. For istance even though the `external.table.purge` is set to `true`, the table data and metadata will not be suppressed with a `DROP TABLE` in spark although it is the case in Hive.



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
