### PR TITLE
fix: Move ranger_admin_password to tdp_cluster

### DIFF
--- a/tdp_vars_defaults/ranger/ranger.yml
+++ b/tdp_vars_defaults/ranger/ranger.yml
@@ -53,7 +53,6 @@ ranger_log_rfa_totalsizecap: 0
 
 
 # Ranger passwords
-ranger_admin_password: RangerAdmin123
 ranger_tagsync_password: RangerTagsync123
 ranger_usersync_password: RangerUsersync123
 ranger_keyadmin_password: RangerKeyAdmin123

--- a/tdp_vars_defaults/tdp-cluster/tdp-cluster.yml
+++ b/tdp_vars_defaults/tdp-cluster/tdp-cluster.yml
@@ -224,6 +224,7 @@ knox_log_dir: /var/log/knox
 knox_gateway_log_file: "knox-gateway_{{ ansible_fqdn }}.log"
 knox_ranger_audit_file: "knox-rangeraudit_{{ ansible_fqdn }}.log"
 
+ranger_admin_password: RangerAdmin123
 ranger_log_dir: /var/log/ranger
 ranger_admin_log_file: "ranger-admin_{{ ansible_fqdn }}.log"
 ranger_usersync_log_file: "ranger-usersync_{{ ansible_fqdn }}.log"


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

Fixes the following error in `hdfs_ranger_init` when variable is not overriden 

```
The task includes an option with an undefined variable. The error was: 'ranger_admin_password' is undefined. 
```

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
