### PR TITLE
fix: hide passwords in ansible logs

### DIFF
--- a/roles/hbase/ranger/tasks/config.yml
+++ b/roles/hbase/ranger/tasks/config.yml
@@ -9,6 +9,7 @@
     owner: root
     group: root
     mode: "644"
+  no_log: "{{ tdp_no_log is not defined or tdp_no_log }}"
 
 # enable-hbase-plugin.sh will only modify configuration files in {{ hbase_root_dir }}/conf
 # There is no way to tell the script to use /etc/hbase/conf.master or /etc/hbase/conf.rs

--- a/roles/hdfs/ranger/tasks/config.yml
+++ b/roles/hdfs/ranger/tasks/config.yml
@@ -9,6 +9,7 @@
     owner: root
     group: root
     mode: "644"
+  no_log: "{{ tdp_no_log is not defined or tdp_no_log }}"
 
 # Ranger installation scripts finds hadoop at "../hadoop" to add necessary properties to hdfs-site.xml, generate the ranger-*.xml
 # It can also be configured with COMPONENT_INSTALL_DIR_NAME but we still have to make /opt/hadoop/etc/hadoop a symbolic link to /etc/hadoop/conf.nn to get the configurations at the right place

--- a/roles/hive/ranger/tasks/config.yml
+++ b/roles/hive/ranger/tasks/config.yml
@@ -9,6 +9,7 @@
     owner: root
     group: root
     mode: "644"
+  no_log: "{{ tdp_no_log is not defined or tdp_no_log }}"
 
 # Ranger installation scripts finds hive at "../hive" to add necessary properties to hive-site.xml, generate the ranger-*.xml
 # It can also be configured with COMPONENT_INSTALL_DIR_NAME but we still have to make {{ hive_install_dir ]]/conf a symbolic link to /etc/hive/conf.s2 to get the configurations at the right place

--- a/roles/knox/gateway/tasks/config.yml
+++ b/roles/knox/gateway/tasks/config.yml
@@ -171,6 +171,7 @@
   loop: "{{ gateway_topology | dict2items }}"
   vars:
     topology: "{{ item.value }}"
+  no_log: "{{ tdp_no_log is not defined or tdp_no_log }}"
 
 - name: Generate Knox master secret
   become_user: knox

--- a/roles/knox/ranger/tasks/config.yml
+++ b/roles/knox/ranger/tasks/config.yml
@@ -9,6 +9,7 @@
     owner: root
     group: root
     mode: "644"
+  no_log: "{{ tdp_no_log is not defined or tdp_no_log }}"
 
 # Ranger installation scripts finds knox at "../knox" to add necessary properties to knox-site.xml, generate the ranger-*.xml
 # It can also be configured with COMPONENT_INSTALL_DIR_NAME but we still have to make {{ knox_install_dir }}/conf

--- a/roles/ranger/admin/tasks/config.yml
+++ b/roles/ranger/admin/tasks/config.yml
@@ -9,6 +9,7 @@
     owner: "{{ ranger_user }}"
     group: "{{ hadoop_group }}"
     mode: "644"
+  no_log: "{{ tdp_no_log is not defined or tdp_no_log }}"
 
 - name: Run setup.sh
   ansible.builtin.shell: |

--- a/roles/ranger/kms/tasks/config.yml
+++ b/roles/ranger/kms/tasks/config.yml
@@ -9,6 +9,7 @@
     owner: "{{ ranger_kms_user }}"
     group: "{{ hadoop_group }}"
     mode: "644"
+  no_log: "{{ tdp_no_log is not defined or tdp_no_log }}"
 
 - name: Run setup.sh
   ansible.builtin.shell: |

--- a/roles/ranger/usersync/tasks/config.yml
+++ b/roles/ranger/usersync/tasks/config.yml
@@ -9,6 +9,7 @@
     owner: "{{ ranger_user }}"
     group: "{{ hadoop_group }}"
     mode: "750"
+  no_log: "{{ tdp_no_log is not defined or tdp_no_log }}"
 
 - name: Setup usersync
   ansible.builtin.shell: |

--- a/roles/yarn/ranger/tasks/config.yml
+++ b/roles/yarn/ranger/tasks/config.yml
@@ -9,6 +9,7 @@
     owner: root
     group: root
     mode: "644"
+  no_log: "{{ tdp_no_log is not defined or tdp_no_log }}"
 
 # Ranger installation scripts finds hadoop at "../hadoop" to add necessary properties to hdfs-site.xml, generate the ranger-*.xml
 # It can also be configured with COMPONENT_INSTALL_DIR_NAME but we still have to make /opt/hadoop/etc/hadoop a symbolic link


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Some passwords are displayed in ansible logs. 
This PR adds a 'no_log' parameters to such ansible tasks. It can be overridden by setting `tdp_no_log` variable to true

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
