### PR TITLE
refactor(mapreduce): remove jhs_ha_address and replace yarn.log.serve…

### DIFF
--- a/tdp_vars_defaults/knox/knox.yml
+++ b/tdp_vars_defaults/knox/knox.yml
@@ -149,9 +149,8 @@ tdpldap_services:
     port: "{{ hdfs_nn_https_port }}"
     version: 2.7.0
   JOBHISTORYUI:
-    hosts: "{% if jhs_ha_address is defined %}{{ jhs_ha_address | urlsplit('hostname') | split(' ') | list }}{% else %}{{ groups['mapred_jhs'] | default([]) | map('tosit.tdp.access_fqdn', hostvars) | list }}{% endif %}"
+    hosts: "{{ groups['mapred_jhs'] | default([]) | map('tosit.tdp.access_fqdn', hostvars) | list }}"
     port: "{{ mapred_jhs_https_port }}"
-    scheme: "{% if jhs_ha_address is defined %}{{ jhs_ha_address | urlsplit('scheme') }}://{% else %}https://{% endif %}"
   HIVE: {}
   RESOURCEMANAGER:
     hosts: "{{ groups['yarn_rm'] | default([]) | map('tosit.tdp.access_fqdn', hostvars) | list }}"

--- a/tdp_vars_defaults/tdp-cluster/tdp-cluster.yml
+++ b/tdp_vars_defaults/tdp-cluster/tdp-cluster.yml
@@ -266,7 +266,6 @@ ldap:
 #############################
 
 # ranger_ha_address: "http[s]://dns_alias:port"
-# jhs_ha_address: "http[s]://dns_alias:port"
 
 #############################
 #  Observability            #

--- a/tdp_vars_defaults/yarn/yarn.yml
+++ b/tdp_vars_defaults/yarn/yarn.yml
@@ -127,7 +127,7 @@ yarn_site:
   yarn.timeline-service.http-authentication.kerberos.keytab: /etc/security/keytabs/spnego.service.keytab
   yarn.acl.enable: "true"
   yarn.admin.acl: yarn,knox
-  yarn.log.server.url: "{% if jhs_ha_address is defined %}{{ jhs_ha_address }}/jobhistory/logs{% else %}https://{{ groups['mapred_jhs'][0] | tosit.tdp.access_fqdn(hostvars) }}:{{ mapred_jhs_https_port }}/jobhistory/logs{% endif %}"
+  yarn.log.server.url: "https://{{ groups['mapred_jhs'][0] | tosit.tdp.access_fqdn(hostvars) }}:{{ mapred_jhs_https_port }}/jobhistory/logs"
   # To enable cgroups
   yarn.nodemanager.linux-container-executor.resources-handler.class: "{% if cgroups_enabled %}org.apache.hadoop.yarn.server.nodemanager.util.CgroupsLCEResourcesHandler{% else %}org.apache.hadoop.yarn.server.nodemanager.util.DefaultLCEResourcesHandler{% endif %}"
   yarn.nodemanager.linux-container-executor.cgroups.mount: "false"


### PR DESCRIPTION
…r.url for mapreduce jobs to knox tdpldap address

<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

Remove the mapreduce jhs address which would come from an external proxy server.



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
