### PR TITLE
fix(playbooks): zk and spark3 status compatible with ansible 2.16

### DIFF
--- a/roles/spark/historyserver/tasks/status.yml
+++ b/roles/spark/historyserver/tasks/status.yml
@@ -8,5 +8,5 @@
 - name: "Assert {{ spark_version | capitalize }} is running"
   ansible.builtin.assert:
     that:
-      - ansible_facts.services['{{ spark_version }}-history-server.service'].state == "running"
+      - ansible_facts.services[spark_version + '-history-server.service'].state == "running"
     quiet: true

--- a/roles/zookeeper/server/tasks/status.yml
+++ b/roles/zookeeper/server/tasks/status.yml
@@ -8,5 +8,5 @@
 - name: "Assert {{ zookeeper_server_service_name }} is running"
   ansible.builtin.assert:
     that:
-      - ansible_facts.services['{{ zookeeper_server_service_name }}.service'].state == "running"
+      - ansible_facts.services[zookeeper_server_service_name + '.service'].state == "running"
     quiet: true


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

Execution of the playbooks Zookeeper et Spark3 fails with the following errors:
```
The conditional check 'ansible_facts.services['{{ zookeeper_server_service_name }}.service'].state == "running"' failed. The error was: Conditional is marked as unsafe, and cannot be evaluated.
fatal: [hky-vm-master-02-dev]: FAILED! => {}
```
```
The conditional check 'ansible_facts.services['{{ spark_version }}-history-server.service'].state == "running"' failed. The error was: Conditional is marked as unsafe, and cannot be evaluated.
```
#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
