### PR TITLE
fix(hdfs): suppress MaxBackupIndex for DailyRollingFileAppender in ra…

### DIFF
--- a/roles/hadoop/common/templates/log4j.properties.j2
+++ b/roles/hadoop/common/templates/log4j.properties.j2
@@ -311,12 +311,11 @@ log4j.appender.EWMA.maxUniqueMessages=${yarn.ewma.maxUniqueMessages}
 log4j.logger.org.apache.commons.beanutils=WARN
 
 {% if enable_ranger_audit_log4j and  ranger_audit_file is defined %}
-ranger.logger=INFO,console,RANGERAUDIT
+ranger.logger=INFO,RANGERAUDIT
 log4j.logger.xaaudit=${ranger.logger}
 log4j.appender.RANGERAUDIT=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.RANGERAUDIT.File={{ ranger_audit_file }}
 log4j.appender.RANGERAUDIT.layout=org.apache.log4j.PatternLayout
 log4j.appender.RANGERAUDIT.layout.ConversionPattern={{ tdp_auditlog_layout_pattern }}
-log4j.appender.RANGERAUDIT.MaxBackupIndex=${hadoop.log.maxbackupindex}
 #log4j.appender.RANGERAUDIT.DatePattern=.yyyy-MM-dd
 {% endif %}


### PR DESCRIPTION
…r.logger as not supported and remove console logger from ranger.logger

<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

- Remove MaxBackupIndex for DailyRollingFileAppende in ranger.loggerr as the property is not supported
- Remove console logger from ranger.logger as both loggers have different ConversionPattern layouts, no ranger auditlogs should be in the  hadoop-hdfs-namenode-*.out file.



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
